### PR TITLE
Harmonize env variable from NATS_SERVER to QOVERY_NATS_URL

### DIFF
--- a/lib/aws/bootstrap/helm-qovery-engine.tf
+++ b/lib/aws/bootstrap/helm-qovery-engine.tf
@@ -28,7 +28,7 @@ resource "helm_release" "qovery_engine_resources" {
   }
 
   set {
-    name = "environmentVariables.NATS_SERVER"
+    name = "environmentVariables.QOVERY_NATS_URL"
     value = var.qovery_nats_url
   }
 

--- a/lib/common/bootstrap/charts/qovery-engine/values.yaml
+++ b/lib/common/bootstrap/charts/qovery-engine/values.yaml
@@ -19,7 +19,7 @@ labels:
 environmentVariables:
   RUST_LOG: DEBUG,rusoto_core::request=info,hyper=info
   #ENGINE_RES_URL: ""
-  #NATS_SERVER: ""
+  #QOVERY_NATS_URL: ""
   #ORGANIZATION: ""
   #CLOUD_PROVIDER: ""
   #REGION: ""

--- a/lib/digitalocean/bootstrap/helm-qovery-engine.tf
+++ b/lib/digitalocean/bootstrap/helm-qovery-engine.tf
@@ -28,7 +28,7 @@ resource "helm_release" "qovery_engine_resources" {
   }
 
   set {
-    name = "environmentVariables.NATS_SERVER"
+    name = "environmentVariables.QOVERY_NATS_URL"
     value = var.qovery_nats_url
   }
 

--- a/src/models.rs
+++ b/src/models.rs
@@ -959,16 +959,16 @@ impl Clone2 for Context {
 
 impl Context {
     pub fn new(
-        execution_id: &str,
-        workspace_root_dir: &str,
-        lib_root_dir: &str,
+        execution_id: String,
+        workspace_root_dir: String,
+        lib_root_dir: String,
         docker_host: Option<String>,
         metadata: Option<Metadata>,
     ) -> Self {
         Context {
-            execution_id: execution_id.to_string(),
-            workspace_root_dir: workspace_root_dir.to_string(),
-            lib_root_dir: lib_root_dir.to_string(),
+            execution_id,
+            workspace_root_dir,
+            lib_root_dir,
             docker_host,
             metadata,
         }

--- a/test_utilities/src/utilities.rs
+++ b/test_utilities/src/utilities.rs
@@ -121,9 +121,9 @@ pub fn context() -> Context {
     };
 
     Context::new(
-        execution_id.as_str(),
-        home_dir.as_str(),
-        lib_root_dir.as_str(),
+        execution_id,
+        home_dir,
+        lib_root_dir,
         None,
         Option::from(metadata),
     )


### PR DESCRIPTION
In order to get the same variable name everywhere
