### PR TITLE
feat: temporary remove kube-state-metrics

### DIFF
--- a/lib/aws/bootstrap/chart_values/prometheus_operator.yaml
+++ b/lib/aws/bootstrap/chart_values/prometheus_operator.yaml
@@ -46,7 +46,7 @@ defaultRules:
     kubernetesStorage: true
     kubernetesSystem: true
     kubeScheduler: true
-    kubeStateMetrics: true
+    kubeStateMetrics: false
     network: true
     node: true
     prometheus: true
@@ -1048,7 +1048,7 @@ kubeProxy:
 ## Component scraping kube state metrics
 ##
 kubeStateMetrics:
-  enabled: true
+  enabled: false
   serviceMonitor:
     ## Scrape interval. If not set, the Prometheus default scrape interval is used.
     ##

--- a/lib/digitalocean/bootstrap/chart_values/prometheus_operator.yaml
+++ b/lib/digitalocean/bootstrap/chart_values/prometheus_operator.yaml
@@ -46,7 +46,7 @@ defaultRules:
     kubernetesStorage: true
     kubernetesSystem: true
     kubeScheduler: true
-    kubeStateMetrics: true
+    kubeStateMetrics: false
     network: true
     node: true
     prometheus: true
@@ -1048,7 +1048,7 @@ kubeProxy:
 ## Component scraping kube state metrics
 ##
 kubeStateMetrics:
-  enabled: true
+  enabled: false
   serviceMonitor:
     ## Scrape interval. If not set, the Prometheus default scrape interval is used.
     ##


### PR DESCRIPTION
Before, we were using kube-state-metrics from Prometheus operator chart. But because we can't control resource usage, it may be preferable to use the dedicated chart for it.
I disable it because Terraform was failing on chart upgrade (because of pod CrashloopBackoff)