### PR TITLE
Do not fail deployment if CNAME is not valid

### DIFF
--- a/src/cloud_provider/digitalocean/router.rs
+++ b/src/cloud_provider/digitalocean/router.rs
@@ -469,12 +469,10 @@ impl Create for Router {
                     continue
                 }
                 Ok(err) | Err(err) => {
-                    return Err(EngineError::new(
-                        EngineErrorCause::User("Invalid CNAME"),
-                        EngineErrorScope::Router(self.id.clone(), self.name.clone()),
-                        self.context.execution_id(),
-                        Some(err.as_str()),
-                    ))
+                    warn!(
+                        "Invalid CNAME for {}. Might not be an issue if user is using a CDN: {}",
+                        domain_to_check.domain, err
+                    );
                 }
             }
         }

--- a/src/cloud_provider/utilities.rs
+++ b/src/cloud_provider/utilities.rs
@@ -288,12 +288,12 @@ pub fn check_cname_for(
         ));
     };
 
-    let send_error_progress = |msg: &str| {
+    let send_warn_progress = |msg: &str| {
         listener_helper.error(ProgressInfo::new(
             ProgressScope::Environment {
                 id: execution_id.to_string(),
             },
-            ProgressLevel::Error,
+            ProgressLevel::Warn,
             Some(msg.to_string()),
             execution_id,
         ));
@@ -326,7 +326,7 @@ pub fn check_cname_for(
         }
         Err(_) => {
             let msg = format!("Resolution of CNAME {} failed !!!", cname_to_check);
-            send_error_progress(msg.as_str());
+            send_warn_progress(msg.as_str());
         }
     }
 


### PR DESCRIPTION
  + For custom domain we ask users to point with a CNAME
    to xxx.qovery.io. If the user is using a CDN, it is not
    possible to check if the configuration is correct as
    there will be no CNAME records avaible and A record
    is going to match IP of the CDN