### PR TITLE
Fix command with timeout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1590,6 +1590,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50e4785f2c3b7589a0d0c1dd60285e1188adac4006e8abd6dd578e1567027363"
+dependencies = [
+ "bitflags",
+ "cc",
+ "cfg-if 0.1.10",
+ "libc",
+ "void",
+]
+
+[[package]]
 name = "ntapi"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1914,6 +1927,7 @@ dependencies = [
  "tar",
  "tera",
  "test-utilities",
+ "timeout-readwrite",
  "tokio 0.2.22",
  "tracing",
  "tracing-subscriber",
@@ -2996,6 +3010,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "timeout-readwrite"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15f9e83663e1c312cbc7980611fa82ed60d622a947de3546350b549e5d69f9bc"
+dependencies = [
+ "nix",
+]
+
+[[package]]
 name = "tinyvec"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3500,6 +3523,12 @@ name = "version_check"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
+
+[[package]]
+name = "void"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ rand = "0.7.3"
 gethostname = "0.2.1"
 reqwest = { version = "0.10.8", features = ["blocking"] }
 futures = "0.3"
+timeout-readwrite = "0.3.1"
 
 # FIXME use https://crates.io/crates/blocking instead of runtime.rs
 


### PR DESCRIPTION
  - reading on stdout/stderr may be blocking if the app does
    not output anything, thus we never reach the code that abort/timeout
    the process

  - Fix: Properly timeout reading stdout/stderr

  - Try to interleave stdout and stderr to have output in the correct
  order. For a better alternative timestamp should be added and remerged
  after it