### PR TITLE
Adding couple basics unit tests

### DIFF
--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -12,3 +12,74 @@ pub fn to_sha1_truncate_16(input: &str) -> String {
     hash_str.truncate(16);
     hash_str
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct TestCase<'a> {
+        input: &'a str,
+        expected_output: String,
+        description: &'a str,
+    }
+
+    #[test]
+    fn test_to_sha1() {
+        // setup:
+        let test_cases: Vec<TestCase> = vec![
+            TestCase {
+                input: "",
+                expected_output: String::from("da39a3ee5e6b4b0d3255bfef95601890afd80709"),
+                description: "empty &str input",
+            },
+            TestCase {
+                input: "abc",
+                expected_output: String::from("a9993e364706816aba3e25717850c26c9cd0d89d"),
+                description: "simple small input 1",
+            },
+            TestCase {
+                input: "abcdefghijklmnopqrstuvwxyz",
+                expected_output: String::from("32d10c7b8cf96570ca04ce37f2a19d84240d3a89"),
+                description: "simple small input 1",
+            },
+        ];
+
+        for tc in test_cases {
+            // execute:
+            let result = to_sha1(tc.input);
+
+            // verify:
+            assert_eq!(tc.expected_output, result, "case {} : '{}'", tc.description, tc.input);
+        }
+    }
+
+    #[test]
+    fn test_to_sha1_truncate_16() {
+        // setup:
+        let test_cases: Vec<TestCase> = vec![
+            TestCase {
+                input: "",
+                expected_output: String::from("da39a3ee5e6b4b0d"),
+                description: "empty &str input",
+            },
+            TestCase {
+                input: "abc",
+                expected_output: String::from("a9993e364706816a"),
+                description: "simple small input 1",
+            },
+            TestCase {
+                input: "abcdefghijklmnopqrstuvwxyz",
+                expected_output: String::from("32d10c7b8cf96570"),
+                description: "simple small input 1",
+            },
+        ];
+
+        for tc in test_cases {
+            // execute:
+            let result = to_sha1_truncate_16(tc.input);
+
+            // verify:
+            assert_eq!(tc.expected_output, result, "case {} : '{}'", tc.description, tc.input);
+        }
+    }
+}

--- a/src/deletion_utilities.rs
+++ b/src/deletion_utilities.rs
@@ -7,29 +7,158 @@ pub fn get_firsts_namespaces_to_delete(namespaces: Vec<&str>) -> Vec<&str> {
 }
 
 fn minus_namespaces<'a>(all: Vec<&'a str>, to_remove_namespaces: Vec<&str>) -> Vec<&'a str> {
-    let reduced = all
-        .into_iter()
+    all.into_iter()
         .filter(|item| !to_remove_namespaces.contains(item))
-        .collect();
-    return reduced;
+        .collect()
 }
 
 pub fn get_qovery_managed_namespaces() -> Vec<&'static str> {
     // order is very important because of dependencies
-    let mut qovery_managed_namespaces = Vec::with_capacity(5);
-    qovery_managed_namespaces.push("logging");
-    qovery_managed_namespaces.push("nginx-ingress");
-    qovery_managed_namespaces.push("qovery");
-    qovery_managed_namespaces.push("cert-manager");
-    qovery_managed_namespaces.push("prometheus");
-    return qovery_managed_namespaces;
+    vec!["logging", "nginx-ingress", "qovery", "cert-manager", "prometheus"]
 }
 
 fn get_never_delete_namespaces() -> Vec<&'static str> {
-    let mut kubernetes_never_delete_namespaces = Vec::with_capacity(4);
-    kubernetes_never_delete_namespaces.push("default");
-    kubernetes_never_delete_namespaces.push("kube-node-lease");
-    kubernetes_never_delete_namespaces.push("kube-public");
-    kubernetes_never_delete_namespaces.push("kube-system");
-    return kubernetes_never_delete_namespaces;
+    vec!["default", "kube-node-lease", "kube-public", "kube-system"]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_get_never_delete_namespaces() {
+        // setup:
+        let expected = vec!["default", "kube-node-lease", "kube-public", "kube-system"];
+
+        // execute:
+        let result = get_never_delete_namespaces();
+
+        // verify:
+        assert_eq!(expected, result);
+    }
+
+    #[test]
+    fn test_get_qovery_managed_namespaces() {
+        // setup:
+        let expected = vec!["logging", "nginx-ingress", "qovery", "cert-manager", "prometheus"];
+
+        // execute:
+        let result = get_never_delete_namespaces();
+
+        // verify:
+        assert_eq!(expected, result);
+    }
+
+    #[test]
+    fn test_minus_namespaces() {
+        // setup:
+        struct TestCase<'a> {
+            input_all: Vec<&'a str>,
+            input_to_be_removed: Vec<&'a str>,
+            expected_output: Vec<&'a str>,
+            description: &'a str,
+        }
+
+        let test_cases: Vec<TestCase> = vec![
+            TestCase {
+                input_all: Vec::new(),
+                input_to_be_removed: Vec::new(),
+                expected_output: Vec::new(),
+                description: "empty vec, nothing to be deleted",
+            },
+            TestCase {
+                input_all: Vec::new(),
+                input_to_be_removed: vec!["a", "c"],
+                expected_output: Vec::new(),
+                description: "empty vec, non empty vec to be deleted",
+            },
+            TestCase {
+                input_all: vec!["a", "b", "c", "d"],
+                input_to_be_removed: Vec::new(),
+                expected_output: vec!["a", "b", "c", "d"],
+                description: "nothing to be deleted",
+            },
+            TestCase {
+                input_all: vec!["a", "b", "c", "d"],
+                input_to_be_removed: vec!["b", "c"],
+                expected_output: vec!["a", "d"],
+                description: "nominal 1",
+            },
+            TestCase {
+                input_all: vec!["a", "b", "c", "d"],
+                input_to_be_removed: vec!["a", "d"],
+                expected_output: vec!["b", "c"],
+                description: "nominal 2",
+            },
+        ];
+
+        for tc in test_cases {
+            // execute:
+            let result = minus_namespaces(tc.input_all.clone(), tc.input_to_be_removed.clone());
+
+            // verify:
+            assert_eq!(
+                tc.expected_output, result,
+                "case: {}, all: {:?} to_be_removed: {:?}",
+                tc.description, tc.input_all, tc.input_to_be_removed
+            );
+        }
+    }
+
+    #[test]
+    fn test_get_firsts_namespaces_to_delete() {
+        // setup:
+        struct TestCase<'a> {
+            input: Vec<&'a str>,
+            expected_output: Vec<&'a str>,
+            description: &'a str,
+        }
+
+        let test_cases: Vec<TestCase> = vec![
+            TestCase {
+                input: Vec::new(),
+                expected_output: Vec::new(),
+                description: "empty vec",
+            },
+            TestCase {
+                input: vec!["a", "b", "c", "d"],
+                expected_output: vec!["a", "b", "c", "d"],
+                description: "everything can be deleted",
+            },
+            TestCase {
+                input: vec![
+                    "a",
+                    "b",
+                    "c",
+                    "d",
+                    "default",
+                    "kube-node-lease",
+                    "kube-public",
+                    "kube-system",
+                ],
+                expected_output: vec!["a", "b", "c", "d"],
+                description: "multiple elements among never to be deleted list",
+            },
+            TestCase {
+                input: vec!["a", "b", "c", "d", "kube-system"],
+                expected_output: vec!["a", "b", "c", "d"],
+                description: "one element among never to be deleted list",
+            },
+        ];
+
+        for tc in test_cases {
+            // execute:
+            let result = get_firsts_namespaces_to_delete(tc.input.clone());
+
+            // verify:
+            assert_eq!(
+                tc.expected_output,
+                result,
+                "case: {}, all: {:?} never_delete: {:?}",
+                tc.description,
+                tc.input,
+                get_never_delete_namespaces()
+            );
+        }
+    }
 }

--- a/src/deletion_utilities.rs
+++ b/src/deletion_utilities.rs
@@ -1,6 +1,6 @@
-// this fn should implements the algorythm describe here: https://qovery.atlassian.net/secure/RapidBoard.jspa?rapidView=10&modal=detail&selectedIssue=DEV-283
+// this fn should implements the algorithm describe here: https://qovery.atlassian.net/secure/RapidBoard.jspa?rapidView=10&modal=detail&selectedIssue=DEV-283
 pub fn get_firsts_namespaces_to_delete(namespaces: Vec<&str>) -> Vec<&str> {
-    // from all namesapce remove managed and never delete namespaces
+    // from all namespaces remove managed and never delete namespaces
     let minus_managed = minus_namespaces(namespaces, get_qovery_managed_namespaces());
     let minus_qovery_managed_and_never_delete = minus_namespaces(minus_managed, get_never_delete_namespaces());
     minus_qovery_managed_and_never_delete
@@ -15,7 +15,7 @@ fn minus_namespaces<'a>(all: Vec<&'a str>, to_remove_namespaces: Vec<&str>) -> V
 }
 
 pub fn get_qovery_managed_namespaces() -> Vec<&'static str> {
-    // the order is very important because of dependencies
+    // order is very important because of dependencies
     let mut qovery_managed_namespaces = Vec::with_capacity(5);
     qovery_managed_namespaces.push("logging");
     qovery_managed_namespaces.push("nginx-ingress");

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -64,7 +64,7 @@ impl<'a> Engine {
         Ok(())
     }
 
-    /// check and init the connection to all the services
+    /// check and init the connection to all services
     pub fn session(&'a self) -> Result<Session<'a>, EngineError> {
         match self.is_valid() {
             Ok(_) => Ok(Session::<'a> { engine: self }),


### PR DESCRIPTION
This PR brings couple changes:
- adds couple basics unit tests on `crypto.rs` and `deletion_utilities.rs`
- fix couple typos in `crypto.rs` and `deletion_utilities.rs`