### PR TITLE
Add support for mono-repo with multiple build context

### DIFF
--- a/src/build_platform/mod.rs
+++ b/src/build_platform/mod.rs
@@ -50,6 +50,7 @@ pub struct GitRepository {
     pub credentials: Option<Credentials>,
     pub commit_id: String,
     pub dockerfile_path: Option<String>,
+    pub root_path: String,
 }
 
 #[derive(Clone, Eq, PartialEq, Hash, Debug)]

--- a/test_utilities/src/aws.rs
+++ b/test_utilities/src/aws.rs
@@ -324,6 +324,7 @@ pub fn environment_3_apps_3_routers_3_databases(context: &Context, secrets: Func
                 git_url: "https://github.com/Qovery/engine-testing.git".to_string(),
                 commit_id: "5990752647af11ef21c3d46a51abbde3da1ab351".to_string(),
                 dockerfile_path: Some("Dockerfile".to_string()),
+                root_path: "/".to_string(),
                 action: Action::Create,
                 git_credentials: Some(GitCredentials {
                     login: "x-access-token".to_string(),
@@ -374,6 +375,7 @@ pub fn environment_3_apps_3_routers_3_databases(context: &Context, secrets: Func
                 git_url: "https://github.com/Qovery/engine-testing.git".to_string(),
                 commit_id: "5990752647af11ef21c3d46a51abbde3da1ab351".to_string(),
                 dockerfile_path: Some("Dockerfile".to_string()),
+                root_path: String::from("/"),
                 action: Action::Create,
                 git_credentials: Some(GitCredentials {
                     login: "x-access-token".to_string(),
@@ -425,6 +427,7 @@ pub fn environment_3_apps_3_routers_3_databases(context: &Context, secrets: Func
                 commit_id: "158ea8ebc9897c50a7c56b910db33ce837ac1e61".to_string(),
                 dockerfile_path: Some(format!("Dockerfile-{}", version_mongo)),
                 action: Action::Create,
+                root_path: String::from("/"),
                 git_credentials: Some(GitCredentials {
                     login: "x-access-token".to_string(),
                     access_token: "xxx".to_string(),
@@ -590,6 +593,7 @@ pub fn working_minimal_environment(context: &Context, secrets: FuncTestsSecrets)
             git_url: "https://github.com/Qovery/engine-testing.git".to_string(),
             commit_id: "fc575a2f3be0b9100492c8a463bf18134a8698a5".to_string(),
             dockerfile_path: Some("Dockerfile".to_string()),
+            root_path: String::from("/"),
             action: Action::Create,
             git_credentials: Some(GitCredentials {
                 login: "x-access-token".to_string(),
@@ -670,6 +674,7 @@ pub fn environnement_2_app_2_routers_1_psql(context: &Context, secrets: FuncTest
                 git_url: "https://github.com/Qovery/engine-testing.git".to_string(),
                 commit_id: "680550d1937b3f90551849c0da8f77c39916913b".to_string(),
                 dockerfile_path: Some("Dockerfile".to_string()),
+                root_path: String::from("/"),
                 action: Action::Create,
                 git_credentials: Some(GitCredentials {
                     login: "x-access-token".to_string(),
@@ -720,6 +725,7 @@ pub fn environnement_2_app_2_routers_1_psql(context: &Context, secrets: FuncTest
                 git_url: "https://github.com/Qovery/engine-testing.git".to_string(),
                 commit_id: "680550d1937b3f90551849c0da8f77c39916913b".to_string(),
                 dockerfile_path: Some("Dockerfile".to_string()),
+                root_path: String::from("/"),
                 action: Action::Create,
                 git_credentials: Some(GitCredentials {
                     login: "x-access-token".to_string(),
@@ -833,6 +839,7 @@ pub fn echo_app_environment(context: &Context, secrets: FuncTestsSecrets) -> Env
             git_url: "https://github.com/Qovery/engine-testing.git".to_string(),
             commit_id: "2205adea1db295547b99f7b17229afd7e879b6ff".to_string(),
             dockerfile_path: Some("Dockerfile".to_string()),
+            root_path: String::from("/"),
             action: Action::Create,
             git_credentials: Some(GitCredentials {
                 login: "x-access-token".to_string(),
@@ -887,6 +894,7 @@ pub fn environment_only_http_server(context: &Context) -> Environment {
             git_url: "https://github.com/Qovery/engine-testing.git".to_string(),
             commit_id: "a873edd459c97beb51453db056c40bca85f36ef9".to_string(),
             dockerfile_path: Some("Dockerfile".to_string()),
+            root_path: String::from("/"),
             action: Action::Create,
             git_credentials: Some(GitCredentials {
                 login: "x-access-token".to_string(),
@@ -927,6 +935,7 @@ pub fn environment_only_http_server_router(context: &Context, secrets: FuncTests
             git_url: "https://github.com/Qovery/engine-testing.git".to_string(),
             commit_id: "a873edd459c97beb51453db056c40bca85f36ef9".to_string(),
             dockerfile_path: Some("Dockerfile".to_string()),
+            root_path: String::from("/"),
             action: Action::Create,
             git_credentials: Some(GitCredentials {
                 login: "x-access-token".to_string(),


### PR DESCRIPTION
- Change to support mono-repo, aka being able to build image from other directory than the root of the repository.

- Fix: Don't try to use buildkit if the specified Dockerfile is not present in the repository