### PR TITLE
Change logging lvl for stderr message during docker build

### DIFF
--- a/src/build_platform/local_docker.rs
+++ b/src/build_platform/local_docker.rs
@@ -120,11 +120,11 @@ impl LocalDocker {
                 let line_string = line.unwrap();
                 error!("{}", line_string.as_str());
 
-                lh.error(ProgressInfo::new(
+                lh.deployment_in_progress(ProgressInfo::new(
                     ProgressScope::Application {
                         id: build.image.application_id.clone(),
                     },
-                    ProgressLevel::Error,
+                    ProgressLevel::Warn,
                     Some(line_string.as_str()),
                     self.context.execution_id(),
                 ));


### PR DESCRIPTION
  + Returning sterr message as error make deployments fails
  + Stderr message can only be warning (i.e: npm messages)
  + Relies on of docker build exit code to tell if build is in error or not
