### PR TITLE
fix: ensure 1 app is always available when only 1 instance is deployed

### DIFF
--- a/lib/aws/charts/q-application/templates/deployment.j2.yaml
+++ b/lib/aws/charts/q-application/templates/deployment.j2.yaml
@@ -16,6 +16,10 @@ spec:
   replicas: {{ total_instances }}
   strategy:
     type: RollingUpdate
+    {% if total_instances == 1 %}
+    rollingUpdate:
+      maxSurge: 1
+    {% endif %}
   selector:
     matchLabels:
       ownerId: {{ owner_id }}

--- a/lib/digitalocean/charts/q-application/templates/deployment.j2.yaml
+++ b/lib/digitalocean/charts/q-application/templates/deployment.j2.yaml
@@ -16,6 +16,10 @@ spec:
   replicas: {{ total_instances }}
   strategy:
     type: RollingUpdate
+    {% if total_instances == 1 %}
+    rollingUpdate:
+      maxSurge: 1
+    {% endif %}
   selector:
     matchLabels:
       ownerId: {{ owner_id }}


### PR DESCRIPTION
When there is one app with only one instance, the rollout delete the app before deploying the new one, causing small downtimes. We now check the number of desired instances and adapt the config if set to 1.