### PR TITLE
Enable publish service for nginx-ingress

### DIFF
--- a/lib/aws/chart_values/nginx-ingress/nginx-ingress.j2.yaml
+++ b/lib/aws/chart_values/nginx-ingress/nginx-ingress.j2.yaml
@@ -87,7 +87,7 @@ controller:
   ## Allows customization of the external service
   ## the ingress will be bound to via DNS
   publishService:
-    enabled: false
+    enabled: true
     ## Allows overriding of the publish service to bind to
     ## Must be <namespace>/<service_name>
     ##


### PR DESCRIPTION
By enabling this option the controller is going to
use a service to know the ingress endpoint/address to use.
In our case, it is going to pick the LB hostname thus
it is going to avoid the need to add on every ingress
target annotation for external DNS with the LB hostname.
This reduce the toil to update LB endpoint when it changes,
as it is done automatically now