### PR TITLE
fix: scaleway router DNS not accessible

### DIFF
--- a/lib/scaleway/bootstrap/chart_values/nginx-ingress.yaml
+++ b/lib/scaleway/bootstrap/chart_values/nginx-ingress.yaml
@@ -21,5 +21,5 @@ controller:
       service.beta.kubernetes.io/scw-loadbalancer-proxy-protocol-v1: "false"
       service.beta.kubernetes.io/scw-loadbalancer-proxy-protocol-v2: "false"
       service.beta.kubernetes.io/scw-loadbalancer-health-check-type: tcp
-      service.beta.kubernetes.io/scw-loadbalancer-use-hostname: "true"
+      service.beta.kubernetes.io/scw-loadbalancer-use-hostname: "false"
     externalTrafficPolicy: "Local"

--- a/test_utilities/src/utilities.rs
+++ b/test_utilities/src/utilities.rs
@@ -436,7 +436,7 @@ where
             Kind::Do => todo!(),
             Kind::Scw => {
                 // TODO(benjaminch): refactor all of this properly
-                let region = Zone::from_str(secrets.clone().SCALEWAY_DEFAULT_REGION.unwrap().as_str()).unwrap();
+                let zone = Zone::from_str(secrets.clone().SCALEWAY_DEFAULT_REGION.unwrap().as_str()).unwrap();
                 let project_id = secrets.clone().SCALEWAY_DEFAULT_PROJECT_ID.unwrap();
                 let secret_access_key = secrets.clone().SCALEWAY_SECRET_KEY.unwrap();
 
@@ -450,7 +450,7 @@ where
 
                 let clusters_res = block_on(scaleway_api_rs::apis::clusters_api::list_clusters(
                     &configuration,
-                    region.to_string().as_str(),
+                    zone.region().to_string().as_str(),
                     None,
                     Some(project_id.as_str()),
                     None,
@@ -486,7 +486,7 @@ where
                             if tag.as_str() == expected_test_server_tag.as_str() {
                                 match block_on(scaleway_api_rs::apis::clusters_api::get_cluster_kube_config(
                                     &configuration,
-                                    region.as_str(),
+                                    zone.region().as_str(),
                                     cluster.id.as_ref().unwrap().as_str(),
                                 )) {
                                     Ok(res) => {


### PR DESCRIPTION
Fixing not working scaleway router declaration preventing to reach service from external DNS.