### PR TITLE
Revert "feat: eks enable vpc peering by default"

### DIFF
--- a/src/cloud_provider/aws/kubernetes/helm_charts.rs
+++ b/src/cloud_provider/aws/kubernetes/helm_charts.rs
@@ -131,11 +131,6 @@ pub fn aws_helm_charts(
                     key: "env.WARM_IP_TARGET".to_string(),
                     value: "10".to_string(),
                 },
-                // enable VPC peering connectivity by default
-                ChartSetValue {
-                    key: "env.AWS_VPC_K8S_CNI_EXTERNALSNAT".to_string(),
-                    value: "true".to_string(),
-                },
                 // maximum number of ENIs that will be attached to the node (k8s recommend to avoid going over 100)
                 ChartSetValue {
                     key: "env.MAX_ENI".to_string(),


### PR DESCRIPTION
This CL introduced a bug preventing AWS cluster to reach the outside
world.

This reverts commit c8e1f2aad1bc8b36d8896be2967555c2238a7ea6.