### PR TITLE
fix: give more memory to cluster-autoscaler

### DIFF
--- a/lib/common/bootstrap/charts/cluster-autoscaler/values.yaml
+++ b/lib/common/bootstrap/charts/cluster-autoscaler/values.yaml
@@ -249,13 +249,13 @@ rbac:
 replicaCount: 1
 
 # resources -- Pod resource requests and limits.
-resources: {}
-  # limits:
+resources:
+  limits:
+    memory: 512Mi
   #   cpu: 100m
-  #   memory: 300Mi
-  # requests:
+  requests:
+    memory: 512Mi
   #   cpu: 100m
-  #   memory: 300Mi
 
 # securityContext -- [Security context for pod](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/)
 securityContext: {}


### PR DESCRIPTION
This CL increase cluster-autoscaler memory from 300Mi to 512Mi. It seems
300Mi is not enough in some cases preventing it to properly boot.