### PR TITLE
refactor: disable CORS by default

### DIFF
--- a/lib/aws/charts/q-ingress-tls/templates/ingress-qovery.j2.yaml
+++ b/lib/aws/charts/q-ingress-tls/templates/ingress-qovery.j2.yaml
@@ -23,8 +23,8 @@ metadata:
     {%- endif %}
     kubernetes.io/ingress.class: "nginx-qovery"
     ingress.kubernetes.io/ssl-redirect: "true"
-    nginx.ingress.kubernetes.io/enable-cors: "true"
-    nginx.ingress.kubernetes.io/cors-allow-headers: "DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Authorization,x-csrftoken"
+    #nginx.ingress.kubernetes.io/enable-cors: "true"
+    #nginx.ingress.kubernetes.io/cors-allow-headers: "DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Authorization,x-csrftoken"
 spec:
   tls:
     {%- if custom_domains|length > 0 %}

--- a/lib/digitalocean/charts/q-ingress-tls/templates/ingress-qovery.j2.yaml
+++ b/lib/digitalocean/charts/q-ingress-tls/templates/ingress-qovery.j2.yaml
@@ -23,6 +23,8 @@ metadata:
     {%- endif %}
     kubernetes.io/ingress.class: "nginx-qovery"
     ingress.kubernetes.io/ssl-redirect: "true"
+    #nginx.ingress.kubernetes.io/enable-cors: "true"
+    #nginx.ingress.kubernetes.io/cors-allow-headers: "DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Authorization,x-csrftoken"
 spec:
   tls:
     {%- if custom_domains|length > 0 %}

--- a/lib/scaleway/charts/q-ingress-tls/templates/ingress-qovery.j2.yaml
+++ b/lib/scaleway/charts/q-ingress-tls/templates/ingress-qovery.j2.yaml
@@ -22,8 +22,8 @@ metadata:
     {%- endif %}
     kubernetes.io/ingress.class: "nginx-qovery"
     ingress.kubernetes.io/ssl-redirect: "true"
-    nginx.ingress.kubernetes.io/enable-cors: "true"
-    nginx.ingress.kubernetes.io/cors-allow-headers: "DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Authorization,x-csrftoken"
+    #nginx.ingress.kubernetes.io/enable-cors: "true"
+    #nginx.ingress.kubernetes.io/cors-allow-headers: "DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Authorization,x-csrftoken"
 spec:
   tls:
     {%- if custom_domains|length > 0 %}


### PR DESCRIPTION
    We're disabling it by default as it's not secure. Was useful for some
    clients but not the things to do.
    It's disabled now but will come back as options to set by the customer
    directly from the UI.
