### PR TITLE
feat: engines as deployments when no builder

### DIFF
--- a/lib/common/bootstrap/charts/qovery-engine/templates/autoscaler.yaml
+++ b/lib/common/bootstrap/charts/qovery-engine/templates/autoscaler.yaml
@@ -3,7 +3,6 @@ apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
 metadata:
   name: qovery-engine
-  namespace: {{ .Values.namespace }}
   labels:
     {{- include "qovery-engine.labels" . | nindent 4 }}
 spec:
@@ -13,7 +12,6 @@ spec:
     name: qovery-engine
   minReplicas: {{ .Values.autoscaler.min_replicas }}
   maxReplicas: {{ .Values.autoscaler.max_replicas }}
-  # todo: k8s 1.18 is required to support scaling policies
   metrics:
     - type: Pods
       pods:

--- a/lib/common/bootstrap/charts/qovery-engine/templates/pdb.yaml
+++ b/lib/common/bootstrap/charts/qovery-engine/templates/pdb.yaml
@@ -2,7 +2,6 @@ apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   name: qovery-engine
-  namespace: {{ .Values.namespace }}
   labels:
     {{- include "qovery-engine.labels" . | nindent 4 }}
 spec:

--- a/lib/common/bootstrap/charts/qovery-engine/templates/secret.yaml
+++ b/lib/common/bootstrap/charts/qovery-engine/templates/secret.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "qovery-engine.fullname" . }}
-  namespace: {{ .Values.namespace }}
   labels:
     {{- include "qovery-engine.labels" . | nindent 4 }}
 type: Opaque

--- a/lib/common/bootstrap/charts/qovery-engine/templates/service.yaml
+++ b/lib/common/bootstrap/charts/qovery-engine/templates/service.yaml
@@ -3,7 +3,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: qovery-engine
-  namespace: {{ .Values.namespace }}
   labels:
     {{- include "qovery-engine.labels" . | nindent 4 }}
 spec:

--- a/lib/common/bootstrap/charts/qovery-engine/templates/serviceaccount.yaml
+++ b/lib/common/bootstrap/charts/qovery-engine/templates/serviceaccount.yaml
@@ -3,7 +3,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "qovery-engine.serviceAccountName" . }}
-  namespace: {{ .Values.namespace }}
   labels:
     {{- include "qovery-engine.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}

--- a/lib/common/bootstrap/charts/qovery-engine/templates/servicemonitor.yaml
+++ b/lib/common/bootstrap/charts/qovery-engine/templates/servicemonitor.yaml
@@ -3,7 +3,6 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: qovery-engine
-  namespace: {{ .Values.namespace }}
   labels:
     {{- include "qovery-engine.labels" . | nindent 4 }}
 spec:

--- a/lib/common/bootstrap/charts/qovery-engine/templates/statefulset-deploy.yaml
+++ b/lib/common/bootstrap/charts/qovery-engine/templates/statefulset-deploy.yaml
@@ -1,14 +1,19 @@
 {{- $kubefullname := include "qovery-engine.fullname" . }}
 apiVersion: apps/v1
+{{ if .Values.buildContainer.enable }}
 kind: StatefulSet
+{{ else }}
+kind: Deployment
+{{ end }}
 metadata:
   name: qovery-engine
-  namespace: {{ .Values.namespace }}
   labels:
     {{- include "qovery-engine.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.autoscaler.min_replicas }}
+  {{ if .Values.buildContainer.enable }}
   serviceName: qovery-engine
+  {{ end }}
   selector:
     matchLabels:
       {{- include "qovery-engine.selectorLabels" . | nindent 6 }}

--- a/lib/common/bootstrap/charts/qovery-engine/values.yaml
+++ b/lib/common/bootstrap/charts/qovery-engine/values.yaml
@@ -7,7 +7,6 @@ image:
   pullPolicy: IfNotPresent
   tag: ""
 
-namespace: "qovery"
 metrics:
   enabled: false
   portName: "metrics"


### PR DESCRIPTION
Engines now supports 2 modes:
1. statefulset when builders are active
2. deployments when no builders to grow faster the number of instances
   and prepare for autoscaling