### PR TITLE
fix: DO cluster naming

### DIFF
--- a/lib/digitalocean/bootstrap/tf-default-vars.j2.tf
+++ b/lib/digitalocean/bootstrap/tf-default-vars.j2.tf
@@ -72,7 +72,7 @@ variable "kubernetes_cluster_id" {
 
 variable "kubernetes_cluster_name" {
   description = "Kubernetes cluster name"
-  default     = "{{ doks_master_name }}"
+  default     = "qovery-{{ doks_cluster_id }}"
   type        = string
 }
 

--- a/tests/digitalocean/do_kubernetes.rs
+++ b/tests/digitalocean/do_kubernetes.rs
@@ -34,7 +34,7 @@ fn create_upgrade_and_destroy_doks_cluster(
         let nodes = test_utilities::digitalocean::do_kubernetes_nodes();
         let cloudflare = dns_provider_cloudflare(&context);
 
-        let cluster_id = format!("qovery-test-{}", generate_cluster_id(region.as_str()));
+        let cluster_id = generate_cluster_id(region.as_str());
 
         let kubernetes = DOKS::new(
             context,
@@ -101,7 +101,7 @@ fn create_and_destroy_doks_cluster(region: Region, secrets: FuncTestsSecrets, te
         let nodes = test_utilities::digitalocean::do_kubernetes_nodes();
         let cloudflare = dns_provider_cloudflare(&context);
 
-        let cluster_id = format!("qovery-test-{}", generate_cluster_id(region.as_str()));
+        let cluster_id = generate_cluster_id(region.as_str());
 
         let kubernetes = DOKS::new(
             context,


### PR DESCRIPTION
Introduces new naming method for DO clusters. New naming will be
`qovery-` followed by the cluster ID.

JIRA: DEV-1009