### PR TITLE
Revert "feat: support dual core stack for VPC config"

### DIFF
--- a/src/cloud_provider/aws/kubernetes/mod.rs
+++ b/src/cloud_provider/aws/kubernetes/mod.rs
@@ -79,7 +79,7 @@ pub struct Options {
     pub elasticsearch_zone_a_subnet_blocks: Vec<String>,
     pub elasticsearch_zone_b_subnet_blocks: Vec<String>,
     pub elasticsearch_zone_c_subnet_blocks: Vec<String>,
-    pub vpc_qovery_network_mode: Option<VpcQoveryNetworkMode>,
+    pub vpc_qovery_network_mode: VpcQoveryNetworkMode,
     pub vpc_cidr_block: String,
     pub eks_cidr_subnet: String,
     pub eks_access_cidr_blocks: Vec<String>,
@@ -208,33 +208,29 @@ impl<'a> EKS<'a> {
         let mut eks_zone_b_subnet_blocks_private = format_ips(&self.options.eks_zone_b_subnet_blocks);
         let mut eks_zone_c_subnet_blocks_private = format_ips(&self.options.eks_zone_c_subnet_blocks);
 
-        if self.options.vpc_qovery_network_mode.is_some() {
-            match self.options.vpc_qovery_network_mode.clone().unwrap() {
-                VpcQoveryNetworkMode::WithNatGateways => {
-                    let max_subnet_zone_a = self.check_odd_subnets("a", &eks_zone_a_subnet_blocks_private)?;
-                    let max_subnet_zone_b = self.check_odd_subnets("b", &eks_zone_b_subnet_blocks_private)?;
-                    let max_subnet_zone_c = self.check_odd_subnets("c", &eks_zone_c_subnet_blocks_private)?;
+        match self.options.vpc_qovery_network_mode {
+            VpcQoveryNetworkMode::WithNatGateways => {
+                let max_subnet_zone_a = self.check_odd_subnets("a", &eks_zone_a_subnet_blocks_private)?;
+                let max_subnet_zone_b = self.check_odd_subnets("b", &eks_zone_b_subnet_blocks_private)?;
+                let max_subnet_zone_c = self.check_odd_subnets("c", &eks_zone_c_subnet_blocks_private)?;
 
-                    let eks_zone_a_subnet_blocks_public: Vec<String> =
-                        eks_zone_a_subnet_blocks_private.drain(max_subnet_zone_a..).collect();
-                    let eks_zone_b_subnet_blocks_public: Vec<String> =
-                        eks_zone_b_subnet_blocks_private.drain(max_subnet_zone_b..).collect();
-                    let eks_zone_c_subnet_blocks_public: Vec<String> =
-                        eks_zone_c_subnet_blocks_private.drain(max_subnet_zone_c..).collect();
+                let eks_zone_a_subnet_blocks_public: Vec<String> =
+                    eks_zone_a_subnet_blocks_private.drain(max_subnet_zone_a..).collect();
+                let eks_zone_b_subnet_blocks_public: Vec<String> =
+                    eks_zone_b_subnet_blocks_private.drain(max_subnet_zone_b..).collect();
+                let eks_zone_c_subnet_blocks_public: Vec<String> =
+                    eks_zone_c_subnet_blocks_private.drain(max_subnet_zone_c..).collect();
 
-                    context.insert("eks_zone_a_subnet_blocks_public", &eks_zone_a_subnet_blocks_public);
-                    context.insert("eks_zone_b_subnet_blocks_public", &eks_zone_b_subnet_blocks_public);
-                    context.insert("eks_zone_c_subnet_blocks_public", &eks_zone_c_subnet_blocks_public);
-                }
-                VpcQoveryNetworkMode::WithoutNatGateways => {}
-            };
-            context.insert(
-                "vpc_qovery_network_mode",
-                &self.options.vpc_qovery_network_mode.clone().unwrap().to_string(),
-            );
-        } else {
-            context.insert("vpc_qovery_network_mode", &"WithoutNatGateways".to_string());
-        }
+                context.insert("eks_zone_a_subnet_blocks_public", &eks_zone_a_subnet_blocks_public);
+                context.insert("eks_zone_b_subnet_blocks_public", &eks_zone_b_subnet_blocks_public);
+                context.insert("eks_zone_c_subnet_blocks_public", &eks_zone_c_subnet_blocks_public);
+            }
+            VpcQoveryNetworkMode::WithoutNatGateways => {}
+        };
+        context.insert(
+            "vpc_qovery_network_mode",
+            &self.options.vpc_qovery_network_mode.to_string(),
+        );
 
         let rds_zone_a_subnet_blocks = format_ips(&self.options.rds_zone_a_subnet_blocks);
         let rds_zone_b_subnet_blocks = format_ips(&self.options.rds_zone_b_subnet_blocks);
@@ -909,10 +905,7 @@ impl<'a> Kubernetes for EKS<'a> {
             test_cluster: self.context.is_test_cluster(),
             aws_access_key_id: self.cloud_provider.access_key_id.to_string(),
             aws_secret_access_key: self.cloud_provider.secret_access_key.to_string(),
-            vpc_qovery_network_mode: match self.options.vpc_qovery_network_mode.clone() {
-                None => VpcQoveryNetworkMode::WithoutNatGateways,
-                Some(x) => x,
-            },
+            vpc_qovery_network_mode: self.options.vpc_qovery_network_mode.clone(),
             ff_log_history_enabled: self.context.is_feature_enabled(&Features::LogsHistory),
             ff_metrics_history_enabled: self.context.is_feature_enabled(&Features::MetricsHistory),
             managed_dns_name: self.dns_provider.domain().to_string(),

--- a/test_utilities/src/aws.rs
+++ b/test_utilities/src/aws.rs
@@ -134,7 +134,7 @@ pub fn eks_options(secrets: FuncTestsSecrets) -> Options {
         elasticsearch_zone_a_subnet_blocks: vec!["10.0.184.0/23".to_string(), "10.0.186.0/23".to_string()],
         elasticsearch_zone_b_subnet_blocks: vec!["10.0.188.0/23".to_string(), "10.0.190.0/23".to_string()],
         elasticsearch_zone_c_subnet_blocks: vec!["10.0.192.0/23".to_string(), "10.0.194.0/23".to_string()],
-        vpc_qovery_network_mode: Some(VpcQoveryNetworkMode::WithoutNatGateways),
+        vpc_qovery_network_mode: VpcQoveryNetworkMode::WithoutNatGateways,
         vpc_cidr_block: "10.0.0.0/16".to_string(),
         eks_cidr_subnet: "20".to_string(),
         eks_access_cidr_blocks: secrets

--- a/tests/aws/aws_kubernetes.rs
+++ b/tests/aws/aws_kubernetes.rs
@@ -113,7 +113,7 @@ fn create_and_destroy_eks_cluster(
         let aws = test_utilities::aws::cloud_provider_aws(&context);
         let nodes = test_utilities::aws::aws_kubernetes_nodes();
         let mut eks_options = eks_options(secrets);
-        eks_options.vpc_qovery_network_mode = Some(vpc_network_mode);
+        eks_options.vpc_qovery_network_mode = vpc_network_mode;
 
         let cloudflare = dns_provider_cloudflare(&context);
 


### PR DESCRIPTION
This reverts commit e3f99b19d6f5df33ecf24a1a366d66f9ad98dc77.
It's not needed anymore to be an option as the core always send it now