### PR TITLE
tests: scaleway desactivating managed db tests

### DIFF
--- a/tests/scaleway/scw_databases.rs
+++ b/tests/scaleway/scw_databases.rs
@@ -624,6 +624,7 @@ fn postgresql_v12_deploy_a_working_dev_environment() {
 #[cfg(feature = "test-scw-managed-services")]
 #[named]
 #[test]
+#[ignored]
 fn postgresql_v10_deploy_a_working_prod_environment() {
     let context = context();
     let secrets = FuncTestsSecrets::new();
@@ -642,6 +643,7 @@ fn postgresql_v10_deploy_a_working_prod_environment() {
 #[cfg(feature = "test-scw-managed-services")]
 #[named]
 #[test]
+#[ignored]
 fn postgresql_v11_deploy_a_working_prod_environment() {
     let context = context();
     let secrets = FuncTestsSecrets::new();
@@ -660,6 +662,7 @@ fn postgresql_v11_deploy_a_working_prod_environment() {
 #[cfg(feature = "test-scw-managed-services")]
 #[named]
 #[test]
+#[ignored]
 fn postgresql_v12_deploy_a_working_prod_environment() {
     let context = context();
     let secrets = FuncTestsSecrets::new();
@@ -1020,6 +1023,7 @@ fn mysql_v8_deploy_a_working_dev_environment() {
 #[cfg(feature = "test-scw-managed-services")]
 #[named]
 #[test]
+#[ignored]
 fn mysql_v8_deploy_a_working_prod_environment() {
     let context = context();
     let secrets = FuncTestsSecrets::new();


### PR DESCRIPTION
For the time being, desactivating those tests as they are failling and
we need to find a proper way to make those work (mainly has to do with
DB ports to be attributed randomly by Scaleway).