### PR TITLE
fix: helm upgrade add wait flag

### DIFF
--- a/src/cmd/helm.rs
+++ b/src/cmd/helm.rs
@@ -118,6 +118,10 @@ where
         "--install",
         "--timeout",
         timeout_string.as_str(),
+        // wait: if set, will wait until all Pods, PVCs, Services, and minimum number of Pods of
+        // a Deployment, StatefulSet, or ReplicaSet are in a ready state before marking the release
+        // as successful. It will wait for as long as --timeout
+        "--wait",
         "--history-max",
         "50",
         "--namespace",


### PR DESCRIPTION
add `--wait` flag to helm upgrade making sure everything is ready before
flagging a release as succesful:

`--wait`: if set, will wait until all Pods, PVCs, Services, and minimum
number of Pods of a Deployment, StatefulSet, or ReplicaSet are in a
ready state before marking the release as successful. It will wait for
as long as --timeout

https://helm.sh/docs/helm/helm_upgrade/#helm-upgrade