### PR TITLE
fix: aws managed services couldn't be deleted

### DIFF
--- a/lib/aws/services/mongodb/main.j2.tf
+++ b/lib/aws/services/mongodb/main.j2.tf
@@ -118,4 +118,7 @@ resource "aws_docdb_cluster" "documentdb_cluster" {
   backup_retention_period = var.backup_retention_period
   preferred_backup_window = var.preferred_backup_window
   skip_final_snapshot = var.skip_final_snapshot
+  {%- if not skip_final_snapshot %}
+  final_snapshot_identifier = var.final_snapshot_name
+  {%- endif %}
 }

--- a/lib/aws/services/mongodb/variables.j2.tf
+++ b/lib/aws/services/mongodb/variables.j2.tf
@@ -120,6 +120,12 @@ variable "skip_final_snapshot" {
   type = bool
 }
 
+variable "final_snapshot_name" {
+  description = "Name of the final snapshot before the database goes deleted"
+  default = "{{ final_snapshot_name }}"
+  type = string
+}
+
 {%- if snapshot is defined %}
 # Snapshots
 variable "snapshot_identifier" {

--- a/lib/aws/services/mysql/main.j2.tf
+++ b/lib/aws/services/mysql/main.j2.tf
@@ -132,6 +132,10 @@ resource "aws_db_instance" "mysql_instance" {
   backup_retention_period = var.backup_retention_period
   backup_window = var.backup_window
   skip_final_snapshot = var.skip_final_snapshot
+  {%- if not skip_final_snapshot %}
+  final_snapshot_identifier = var.final_snapshot_name
+  {%- endif %}
+  copy_tags_to_snapshot = true
   delete_automated_backups = var.delete_automated_backups
 
 }

--- a/lib/aws/services/mysql/variables.j2.tf
+++ b/lib/aws/services/mysql/variables.j2.tf
@@ -164,6 +164,12 @@ variable "skip_final_snapshot" {
   type = bool
 }
 
+variable "final_snapshot_name" {
+  description = "Name of the final snapshot before the database goes deleted"
+  default = "{{ final_snapshot_name }}"
+  type = string
+}
+
 {%- if snapshot is defined %}
 # Snapshots
 variable "snapshot_identifier" {

--- a/lib/aws/services/postgresql/main.j2.tf
+++ b/lib/aws/services/postgresql/main.j2.tf
@@ -116,6 +116,10 @@ resource "aws_db_instance" "postgresql_instance" {
   backup_retention_period = var.backup_retention_period
   backup_window = var.backup_window
   skip_final_snapshot = var.skip_final_snapshot
+  {%- if not skip_final_snapshot %}
+  final_snapshot_identifier = var.final_snapshot_name
+  {%- endif %}
+  copy_tags_to_snapshot = true
   delete_automated_backups = var.delete_automated_backups
 
 }

--- a/lib/aws/services/postgresql/variables.j2.tf
+++ b/lib/aws/services/postgresql/variables.j2.tf
@@ -172,6 +172,12 @@ variable "skip_final_snapshot" {
   type = bool
 }
 
+variable "final_snapshot_name" {
+  description = "Name of the final snapshot before the database goes deleted"
+  default = "{{ final_snapshot_name }}"
+  type = string
+}
+
 # Snapshots
 #variable "snapshot_identifier" {
 #  description = "Snapshot ID to restore"

--- a/lib/aws/services/redis/main.j2.tf
+++ b/lib/aws/services/redis/main.j2.tf
@@ -106,8 +106,8 @@ resource "aws_elasticache_cluster" "elasticache_cluster" {
   # Backups
   snapshot_window = var.preferred_backup_window
   snapshot_retention_limit = var.backup_retention_period
-  {%- if skip_final_snapshot %}
-  final_snapshot_identifier = "${var.elasticache_identifier}-final"
+  {%- if not skip_final_snapshot %}
+  final_snapshot_identifier = var.final_snapshot_name
   {%- endif %}
 
 }

--- a/lib/aws/services/redis/variables.j2.tf
+++ b/lib/aws/services/redis/variables.j2.tf
@@ -114,6 +114,12 @@ variable "preferred_backup_window" {
   type = string
 }
 
+variable "final_snapshot_name" {
+  description = "Name of the final snapshot before the database goes deleted"
+  default = "{{ final_snapshot_name }}"
+  type = string
+}
+
 {%- if snapshot is defined %}
 # Snapshots
 variable "snapshot_identifier" {

--- a/src/cloud_provider/aws/databases/mongodb.rs
+++ b/src/cloud_provider/aws/databases/mongodb.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 
+use crate::cloud_provider::aws::databases::utilities::aws_final_snapshot_name;
 use tera::Context as TeraContext;
 
 use crate::cloud_provider::service::{
@@ -180,7 +181,8 @@ impl Service for MongoDB {
         context.insert("tfstate_suffix_name", &get_tfstate_suffix(self));
         context.insert("tfstate_name", &get_tfstate_name(self));
 
-        context.insert("skip_final_snapshot", &self.context().is_test_cluster());
+        context.insert("skip_final_snapshot", &false);
+        context.insert("final_snapshot_name", &aws_final_snapshot_name(self.id()));
         if self.context.resource_expiration_in_seconds().is_some() {
             context.insert(
                 "resource_expiration_in_seconds",

--- a/src/cloud_provider/aws/databases/mysql.rs
+++ b/src/cloud_provider/aws/databases/mysql.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use tera::Context as TeraContext;
 
-use crate::cloud_provider::aws::databases::utilities::get_parameter_group_from_version;
+use crate::cloud_provider::aws::databases::utilities::{aws_final_snapshot_name, get_parameter_group_from_version};
 use crate::cloud_provider::service::{
     check_service_version, default_tera_context, delete_stateful_service, deploy_stateful_service, get_tfstate_name,
     get_tfstate_suffix, scale_down_database, send_progress_on_long_task, Action, Backup, Create, Database,
@@ -191,8 +191,9 @@ impl Service for MySQL {
         context.insert("tfstate_suffix_name", &get_tfstate_suffix(self));
         context.insert("tfstate_name", &get_tfstate_name(self));
 
+        context.insert("skip_final_snapshot", &false);
+        context.insert("final_snapshot_name", &aws_final_snapshot_name(self.id()));
         context.insert("delete_automated_backups", &self.context().is_test_cluster());
-        context.insert("skip_final_snapshot", &self.context().is_test_cluster());
         if self.context.resource_expiration_in_seconds().is_some() {
             context.insert(
                 "resource_expiration_in_seconds",

--- a/src/cloud_provider/aws/databases/postgresql.rs
+++ b/src/cloud_provider/aws/databases/postgresql.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 
+use crate::cloud_provider::aws::databases::utilities::aws_final_snapshot_name;
 use tera::Context as TeraContext;
 
 use crate::cloud_provider::service::{
@@ -177,7 +178,8 @@ impl Service for PostgreSQL {
         context.insert("tfstate_suffix_name", &get_tfstate_suffix(self));
         context.insert("tfstate_name", &get_tfstate_name(self));
 
-        context.insert("skip_final_snapshot", &self.context().is_test_cluster());
+        context.insert("skip_final_snapshot", &false);
+        context.insert("final_snapshot_name", &aws_final_snapshot_name(self.id()));
         context.insert("delete_automated_backups", &self.context().is_test_cluster());
 
         if self.context.resource_expiration_in_seconds().is_some() {

--- a/src/cloud_provider/aws/databases/redis.rs
+++ b/src/cloud_provider/aws/databases/redis.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 
+use crate::cloud_provider::aws::databases::utilities::aws_final_snapshot_name;
 use tera::Context as TeraContext;
 
 use crate::cloud_provider::service::{
@@ -191,7 +192,8 @@ impl Service for Redis {
         context.insert("tfstate_suffix_name", &get_tfstate_suffix(self));
         context.insert("tfstate_name", &get_tfstate_name(self));
 
-        context.insert("skip_final_snapshot", &self.context().is_test_cluster());
+        context.insert("skip_final_snapshot", &false);
+        context.insert("final_snapshot_name", &aws_final_snapshot_name(self.id()));
         if self.context.resource_expiration_in_seconds().is_some() {
             context.insert(
                 "resource_expiration_in_seconds",

--- a/src/cloud_provider/aws/databases/utilities.rs
+++ b/src/cloud_provider/aws/databases/utilities.rs
@@ -27,6 +27,11 @@ pub fn get_parameter_group_from_version(version: &str, database_kind: DatabaseKi
     }
 }
 
+// name of the last snapshot before the database get deleted
+pub fn aws_final_snapshot_name(database_name: &str) -> String {
+    format!("qovery-{}-final-snap", database_name)
+}
+
 #[cfg(test)]
 mod tests_aws_databases_parameters {
     use crate::cloud_provider::aws::databases::utilities::get_parameter_group_from_version;


### PR DESCRIPTION
Note: this makes tests way longer, but this is the only way to test it
properly. If it was the case before, this bug would never happen