### PR TITLE
tests: SCW update infra tests

### DIFF
--- a/tests/scaleway/scw_kubernetes.rs
+++ b/tests/scaleway/scw_kubernetes.rs
@@ -167,6 +167,7 @@ fn create_and_destroy_kapsule_cluster(zone: Zone, secrets: FuncTestsSecrets, tes
 
 #[cfg(feature = "test-scw-infra")]
 #[named]
+#[ignore]
 #[test]
 fn create_and_destroy_kapsule_cluster_par_1() {
     let zone = Zone::Paris1;
@@ -177,8 +178,6 @@ fn create_and_destroy_kapsule_cluster_par_1() {
 #[cfg(feature = "test-scw-infra")]
 #[named]
 #[test]
-#[ignore]
-#[allow(dead_code)]
 fn create_and_destroy_kapsule_cluster_par_2() {
     let zone = Zone::Paris2;
     let secrets = FuncTestsSecrets::new();
@@ -189,7 +188,6 @@ fn create_and_destroy_kapsule_cluster_par_2() {
 #[named]
 #[test]
 #[ignore]
-#[allow(dead_code)]
 fn create_and_destroy_kapsule_cluster_ams_1() {
     let zone = Zone::Amsterdam1;
     let secrets = FuncTestsSecrets::new();
@@ -208,8 +206,6 @@ fn create_and_destroy_kapsule_cluster_war_1() {
 // only enable this test manually when we want to perform and validate upgrade process
 #[test]
 #[ignore]
-#[allow(dead_code)]
-#[allow(unused_attributes)]
 #[named]
 fn create_upgrade_and_destroy_kapsule_cluster_in_par_1() {
     let zone = Zone::Paris1;
@@ -220,8 +216,6 @@ fn create_upgrade_and_destroy_kapsule_cluster_in_par_1() {
 // only enable this test manually when we want to perform and validate upgrade process
 #[test]
 #[ignore]
-#[allow(unused_attributes)]
-#[allow(dead_code)]
 #[named]
 fn create_upgrade_and_destroy_kapsule_cluster_in_par_2() {
     let zone = Zone::Paris2;
@@ -232,8 +226,6 @@ fn create_upgrade_and_destroy_kapsule_cluster_in_par_2() {
 // only enable this test manually when we want to perform and validate upgrade process
 #[test]
 #[ignore]
-#[allow(unused_attributes)]
-#[allow(dead_code)]
 #[named]
 fn create_upgrade_and_destroy_kapsule_cluster_in_ams_1() {
     let zone = Zone::Amsterdam1;
@@ -244,8 +236,6 @@ fn create_upgrade_and_destroy_kapsule_cluster_in_ams_1() {
 // only enable this test manually when we want to perform and validate upgrade process
 #[test]
 #[ignore]
-#[allow(unused_attributes)]
-#[allow(dead_code)]
 #[named]
 fn create_upgrade_and_destroy_kapsule_cluster_in_war_1() {
     let zone = Zone::Warsaw1;


### PR DESCRIPTION
- remove useless SCW infra tests attributes
- ignores infra cluster creation test in Paris 1
- activate infra cluster creation test in Paris 2