### PR TITLE
Do not always fail helm on stderr message

### DIFF
--- a/src/cloud_provider/helm.rs
+++ b/src/cloud_provider/helm.rs
@@ -80,6 +80,7 @@ pub struct ChartInfo {
     pub values: Vec<ChartSetValue>,
     pub values_files: Vec<String>,
     pub yaml_files_content: Vec<ChartValuesGenerated>,
+    pub parse_stderr_for_error: bool,
 }
 
 impl ChartInfo {
@@ -89,6 +90,7 @@ impl ChartInfo {
         custom_namespace: String,
         timeout_in_seconds: i64,
         values_files: Vec<String>,
+        parse_stderr_for_error: bool,
     ) -> Self {
         ChartInfo {
             name,
@@ -97,6 +99,7 @@ impl ChartInfo {
             custom_namespace: Some(custom_namespace),
             timeout_in_seconds,
             values_files,
+            parse_stderr_for_error,
             ..Default::default()
         }
     }
@@ -126,6 +129,7 @@ impl Default for ChartInfo {
             values: Vec::new(),
             values_files: Vec::new(),
             yaml_files_content: vec![],
+            parse_stderr_for_error: true,
         }
     }
 }

--- a/src/cmd/helm.rs
+++ b/src/cmd/helm.rs
@@ -55,15 +55,6 @@ where
         chart_root_dir.as_ref().to_str().unwrap()
     );
 
-    // let _ = helm_exec_upgrade(
-    //     kubernetes_config.as_ref(),
-    //     namespace,
-    //     release_name,
-    //     chart_root_dir.as_ref(),
-    //     timeout,
-    //     envs.clone(),
-    // )?;
-
     let path = match chart_root_dir.as_ref().to_str().is_some() {
         true => chart_root_dir.as_ref().to_str().unwrap(),
         false => "",
@@ -80,6 +71,7 @@ where
                 ServiceType::Database(_) => vec![format!("{}/q-values.yaml", path)],
                 _ => vec![],
             },
+            false,
         ),
     };
 
@@ -229,21 +221,33 @@ where
             kind: SimpleErrorKind::Other,
             message: None,
         };
-        match helm_exec_with_output(
+        let mut should_clean_helm_lock = false;
+
+        let helm_ret = helm_exec_with_output(
             args,
             envs.clone(),
             |out| match out {
                 Ok(line) => {
                     info!("{}", line);
-                    if debug {
-                        debug!("{}", line);
-                    }
                     json_output_string = line
                 }
                 Err(err) => error!("{}", &err),
             },
             |out| match out {
                 Ok(line) => {
+                    if line.contains("another operation (install/upgrade/rollback) is in progress") {
+                        error_message = format!("helm lock detected for {}, looking for cleaning lock", chart.name);
+                        helm_error_during_deployment.message = Some(error_message.clone());
+                        warn!("{}. {}", &error_message, &line);
+                        should_clean_helm_lock = true;
+                        return;
+                    }
+
+                    if !chart.parse_stderr_for_error {
+                        warn!("chart {}: {}", chart.name, line);
+                        return;
+                    }
+
                     // helm errors are not json formatted unfortunately
                     if line.contains("has been rolled back") {
                         error_message = format!("deployment {} has been rolled back", chart.name);
@@ -253,21 +257,7 @@ where
                         error_message = format!("deployment {} has been uninstalled due to failure", chart.name);
                         helm_error_during_deployment.message = Some(error_message.clone());
                         warn!("{}. {}", &error_message, &line);
-                    } else if line.contains("another operation (install/upgrade/rollback) is in progress") {
-                        error_message = format!("helm lock detected for {}, looking for cleaning lock", chart.name);
-                        helm_error_during_deployment.message = Some(error_message.clone());
-                        warn!("{}. {}", &error_message, &line);
-                        match clean_helm_lock(
-                            &kubernetes_config,
-                            chart.get_namespace_string().as_str(),
-                            &chart.name,
-                            chart.timeout_in_seconds,
-                            envs.clone(),
-                        ) {
-                            Ok(_) => info!("Helm lock detected and cleaned"),
-                            Err(e) => warn!("Couldn't cleanup Helm lock. {:?}", e.message),
-                        }
-                    // special fix for prometheus operator
+                        // special fix for prometheus operator
                     } else if line.contains("info: skipping unknown hook: \"crd-install\"") {
                         debug!("chart {}: {}", chart.name, line);
                     } else {
@@ -282,7 +272,22 @@ where
                     error!("{}", error_message);
                 }
             },
-        ) {
+        );
+
+        if should_clean_helm_lock {
+            match clean_helm_lock(
+                &kubernetes_config,
+                chart.get_namespace_string().as_str(),
+                &chart.name,
+                chart.timeout_in_seconds,
+                envs.clone(),
+            ) {
+                Ok(_) => info!("Helm lock detected and cleaned"),
+                Err(e) => warn!("Couldn't cleanup Helm lock. {:?}", e.message),
+            }
+        }
+
+        match helm_ret {
             Ok(_) => {
                 if helm_error_during_deployment.message.is_some() {
                     OperationResult::Retry(helm_error_during_deployment)
@@ -907,7 +912,7 @@ where
         Err(err) => match err.kind {
             SimpleErrorKind::Command(exit_status) => match exit_status.code() {
                 Some(exit_status_code) => {
-                    if exit_status_code == 1 {
+                    if exit_status_code == 0 {
                         Ok(())
                     } else {
                         Err(err)

--- a/src/models.rs
+++ b/src/models.rs
@@ -546,7 +546,6 @@ pub struct Database {
     pub activate_high_availability: bool,
     #[serde(default)] // => false if not present in input
     pub activate_backups: bool,
-    #[serde(default)] // => false if not present in input
     pub publicly_accessible: bool,
     pub mode: DatabaseMode,
 }


### PR DESCRIPTION
- move helm lock clean outside the Clojure receiving logs, because there is no guarantee that the Helm process is terminated at this moment. Doing it at this location can result of removing the lock while helm is still running.

- Don't try to parse stderr if the flag is not set. I am not  even sure that checking stderr is necessary, because I think it was just the helm process exit status that was not properly propagated.  exit_status == 1 returnin Ok(()), making believe helm succeeded.

 