### PR TITLE
Fix un-wanted router deletion

### DIFF
--- a/src/cloud_provider/aws/router.rs
+++ b/src/cloud_provider/aws/router.rs
@@ -2,8 +2,9 @@ use tera::Context as TeraContext;
 
 use crate::cloud_provider::models::{CustomDomain, CustomDomainDataTemplate, Route, RouteDataTemplate};
 use crate::cloud_provider::service::{
-    default_tera_context, delete_router, delete_stateless_service, send_progress_on_long_task, Action, Create, Delete,
-    Helm, Pause, Router as RRouter, Service, ServiceType, StatelessService,
+    default_tera_context, delete_router, delete_stateless_service, deploy_stateless_service_error,
+    send_progress_on_long_task, Action, Create, Delete, Helm, Pause, Router as RRouter, Service, ServiceType,
+    StatelessService,
 };
 use crate::cloud_provider::utilities::{check_cname_for, sanitize_name};
 use crate::cloud_provider::DeploymentTarget;
@@ -333,7 +334,7 @@ impl Create for Router {
         warn!("AWS.router.on_create_error() called for {}", self.name());
 
         send_progress_on_long_task(self, crate::cloud_provider::service::Action::Create, || {
-            delete_stateless_service(target, self, true)
+            deploy_stateless_service_error(target, self)
         })
     }
 }

--- a/src/cloud_provider/digitalocean/router.rs
+++ b/src/cloud_provider/digitalocean/router.rs
@@ -2,8 +2,8 @@ use tera::Context as TeraContext;
 
 use crate::cloud_provider::models::{CustomDomain, CustomDomainDataTemplate, Route, RouteDataTemplate};
 use crate::cloud_provider::service::{
-    default_tera_context, delete_router, delete_stateless_service, send_progress_on_long_task, Action, Create, Delete,
-    Helm, Pause, Service, ServiceType, StatelessService,
+    default_tera_context, delete_router, delete_stateless_service, deploy_stateless_service_error,
+    send_progress_on_long_task, Action, Create, Delete, Helm, Pause, Service, ServiceType, StatelessService,
 };
 use crate::cloud_provider::utilities::{check_cname_for, sanitize_name};
 use crate::cloud_provider::DeploymentTarget;
@@ -354,7 +354,7 @@ impl Create for Router {
         warn!("DO.router.on_create_error() called for {}", self.name());
 
         send_progress_on_long_task(self, crate::cloud_provider::service::Action::Create, || {
-            delete_stateless_service(target, self, true)
+            deploy_stateless_service_error(target, self)
         })
     }
 }

--- a/src/cloud_provider/scaleway/router.rs
+++ b/src/cloud_provider/scaleway/router.rs
@@ -2,8 +2,9 @@ use tera::Context as TeraContext;
 
 use crate::cloud_provider::models::{CustomDomain, CustomDomainDataTemplate, Route, RouteDataTemplate};
 use crate::cloud_provider::service::{
-    default_tera_context, delete_router, delete_stateless_service, send_progress_on_long_task, Action, Create, Delete,
-    Helm, Pause, Router as RRouter, Service, ServiceType, StatelessService,
+    default_tera_context, delete_router, delete_stateless_service, deploy_stateless_service_error,
+    send_progress_on_long_task, Action, Create, Delete, Helm, Pause, Router as RRouter, Service, ServiceType,
+    StatelessService,
 };
 use crate::cloud_provider::utilities::{check_cname_for, sanitize_name};
 use crate::cloud_provider::DeploymentTarget;
@@ -298,7 +299,7 @@ impl Create for Router {
         warn!("SCW.router.on_create_error() called for {}", self.name());
 
         send_progress_on_long_task(self, crate::cloud_provider::service::Action::Create, || {
-            delete_stateless_service(target, self, true)
+            deploy_stateless_service_error(target, self)
         })
     }
 }


### PR DESCRIPTION
- When deployment of an env fail, the upper layer is calling
  on_create_error() on all services (db + app + routers)
  thus if an app fails to be deployed we delete his router/ingress
  leaving his environment broken