### PR TITLE
Refacto git operations

### DIFF
--- a/src/build_platform/local_docker.rs
+++ b/src/build_platform/local_docker.rs
@@ -9,7 +9,6 @@ use crate::cmd::utilities::QoveryCommand;
 use crate::error::{EngineError, EngineErrorCause, SimpleError, SimpleErrorKind};
 use crate::fs::workspace_directory;
 use crate::git;
-use crate::git::checkout_submodules;
 use crate::models::{
     Context, Listen, Listener, Listeners, ListenersHelper, ProgressInfo, ProgressLevel, ProgressScope,
 };
@@ -338,7 +337,7 @@ impl BuildPlatform for LocalDocker {
         // git checkout to given commit
         let repo = git_clone.unwrap();
         let commit_id = &build.git_repository.commit_id;
-        if let Err(err) = git::checkout(&repo, commit_id, build.git_repository.url.as_str()) {
+        if let Err(err) = git::checkout(&repo, commit_id) {
             let message = format!(
                 "Error while git checkout repository {} with commit id {}. Error: {:?}",
                 &build.git_repository.url, commit_id, err
@@ -348,7 +347,7 @@ impl BuildPlatform for LocalDocker {
         }
 
         // git checkout submodules
-        if let Err(err) = checkout_submodules(&repo) {
+        if let Err(err) = git::checkout_submodules(&repo) {
             let message = format!(
                 "Error while checkout submodules from repository {}. Error: {:?}",
                 &build.git_repository.url, err

--- a/src/git.rs
+++ b/src/git.rs
@@ -1,91 +1,147 @@
 use std::path::Path;
 
-use git2::build::RepoBuilder;
-use git2::{Error, Oid, Repository};
+use git2::build::{CheckoutBuilder, RepoBuilder};
+use git2::ResetType::Hard;
+use git2::{Error, Repository};
+use url::Url;
 
-/// TODO support SSH repository_url - we assume that the repository URL starts with HTTPS
-/// TODO support git submodules
+pub struct Credentials {
+    pub login: String,
+    pub password: String,
+}
+
 pub fn clone<P>(repository_url: &str, into_dir: P, credentials: &Option<Credentials>) -> Result<Repository, Error>
 where
     P: AsRef<Path>,
 {
-    let final_repository_url = match credentials {
-        Some(c) => format!(
-            "https://{}:{}@{}",
-            c.login,
-            c.password,
-            repository_url.replace("https://", "")
-        ),
-        None => repository_url.to_string(),
+    let mut url = Url::parse(repository_url)
+        .map_err(|err| Error::from_str(format!("Invalid repository url {}: {}", repository_url, err).as_str()))?;
+
+    if url.scheme() != "https" {
+        return Err(Error::from_str("Repository URL have to start with https://"));
+    }
+
+    if let Some(Credentials { login, password }) = credentials {
+        url.set_username(login).map_err(|_| Error::from_str("Invalid login"))?;
+        url.set_password(Some(password))
+            .map_err(|_| Error::from_str("Invalid password"))?;
     };
 
-    RepoBuilder::new().clone(final_repository_url.as_str(), into_dir.as_ref())
+    RepoBuilder::new().clone(url.as_str(), into_dir.as_ref())
 }
 
-pub fn checkout(repo: &Repository, commit_id: &str, repo_url: &str) -> Result<(), Error> {
-    let oid = match Oid::from_str(commit_id) {
-        Err(e) => {
-            let x = git2::Error::from_str(
-                format!(
-                    "Error while trying to validate commit ID {} on repository {}: {}",
-                    &commit_id, &repo_url, &e
-                )
-                .as_ref(),
-            );
-            return Err(x);
-        }
-        Ok(o) => o,
-    };
+pub fn checkout(repo: &Repository, commit_id: &str) -> Result<(), Error> {
+    let obj = repo.revparse_single(commit_id).map_err(|err| {
+        let repo_url = repo
+            .find_remote("origin")
+            .map(|remote| remote.url().unwrap_or_default().to_string())
+            .unwrap_or_default();
+        let msg = format!(
+            "Unable to use git object commit ID {} on repository {}: {}",
+            &commit_id, &repo_url, &err
+        );
+        Error::from_str(&msg)
+    })?;
 
-    let _ = match repo.find_commit(oid) {
-        Err(e) => {
-            let mut x = git2::Error::from_str(
-                format!("Commit ID {} on repository {} was not found", &commit_id, &repo_url).as_ref(),
-            );
-            x.set_code(e.code());
-            x.set_class(e.class());
-            return Err(x);
-        }
-        Ok(c) => c,
-    };
+    // Specify some options to be sure repository is in a clean state
+    let mut checkout_opts = CheckoutBuilder::new();
+    checkout_opts.force().remove_ignored(true).remove_untracked(true);
 
-    let obj = match repo.revparse_single(commit_id) {
-        Err(e) => {
-            let x = git2::Error::from_str(
-                format!(
-                    "Wasn't able to use git object commit ID {} on repository {}: {}",
-                    &commit_id, &repo_url, &e
-                )
-                .as_ref(),
-            );
-            return Err(x);
-        }
-        Ok(o) => o,
-    };
-
-    let _ = repo.checkout_tree(&obj, None);
-
-    repo.set_head(&("refs/heads/".to_owned() + commit_id))
+    repo.reset(&obj, Hard, Some(&mut checkout_opts))
 }
 
 pub fn checkout_submodules(repo: &Repository) -> Result<(), Error> {
-    match repo.submodules() {
-        Ok(submodules) => {
-            for mut submodule in submodules {
-                info!("getting submodule {:?} from {:?}", submodule.name(), submodule.url());
-
-                if let Err(e) = submodule.update(true, None) {
-                    return Err(e);
-                }
-            }
-        }
-        Err(err) => return Err(err),
+    for mut submodule in repo.submodules()? {
+        info!("getting submodule {:?} from {:?}", submodule.name(), submodule.url());
+        submodule.update(true, None)?
     }
 
     Ok(())
 }
 
-pub struct Credentials {
-    pub login: String,
-    pub password: String,
+#[cfg(test)]
+mod tests {
+    use crate::git::{checkout, clone, Credentials};
+
+    struct DirectoryToDelete<'a> {
+        pub path: &'a str,
+    }
+
+    impl<'a> Drop for DirectoryToDelete<'a> {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(self.path);
+        }
+    }
+
+    #[test]
+    fn test_git_clone_repository() {
+        // We only allow https:// at the moment
+        let repo = clone("git@github.com:Qovery/engine.git", "/tmp", &None);
+        assert!(matches!(repo, Err(e) if e.message().contains("Invalid repository")));
+
+        // Repository must be empty
+        let repo = clone("https://github.com/Qovery/engine.git", "/tmp", &None);
+        assert!(matches!(repo, Err(e) if e.message().contains("'/tmp' exists and is not an empty directory")));
+
+        // Working case
+        {
+            let clone_dir = DirectoryToDelete {
+                path: "/tmp/engine_test_clone",
+            };
+            let repo = clone("https://github.com/Qovery/engine.git", clone_dir.path, &None);
+            assert!(matches!(repo, Ok(_repo)));
+        }
+
+        // Invalid credentials
+        {
+            let clone_dir = DirectoryToDelete {
+                path: "/tmp/engine_test_clone",
+            };
+            let creds = Some(Credentials {
+                login: "FAKE".to_string(),
+                password: "FAKE".to_string(),
+            });
+            let repo = clone("https://gitlab.com/qovery/q-core.git", clone_dir.path, &creds);
+            assert!(matches!(repo, Err(repo) if repo.message().contains("authentication")));
+        }
+
+        /*
+        // Test with bitbucket credentials
+        // This is a toy account feel free to trash it
+        {
+            let clone_dir = DirectoryToDelete {
+                path: "/tmp/engine_test_clone",
+            };
+            let creds = Some(Credentials {
+                login: "{a45d7986-7994-43a9-a961-044799e761d7}".to_string(),
+                password: "3uDbu-i3kdanLRV6iSSWzWDJf4oUQu2hbUQ250DMezFEkkmz3oxPRiAcj7RuLrNgmKu7qx6XA820uvvyfUCdx06bt4VCaOZQkEwkWVksNpAkPE1Lw8gPcnEK".to_string(),
+            });
+            let repo = clone(
+                "https://bitbucket.org/erebe/attachment-parser.git",
+                clone_dir.path,
+                &creds,
+            );
+            assert!(matches!(repo, Ok(_)));
+        }
+        */
+    }
+
+    #[test]
+    fn test_git_checkout() {
+        let clone_dir = DirectoryToDelete {
+            path: "/tmp/engine_test_checkout",
+        };
+        let repo = clone("https://github.com/Qovery/engine.git", clone_dir.path, &None).unwrap();
+
+        // Invalid commit for this repository
+        let check = checkout(&repo, "c2c2101f8e4c4ffadb326dc440ba8afb4aeb1310");
+        assert!(matches!(check, Err(_err)));
+
+        // Valid commit
+        let commit = "9da0f98b5eb719643263abba062041708fa20d31";
+        assert_ne!(repo.head().unwrap().target().unwrap().to_string(), commit);
+        let check = checkout(&repo, commit);
+        assert!(matches!(check, Ok(())));
+        assert_eq!(repo.head().unwrap().target().unwrap().to_string(), commit);
+    }
 }


### PR DESCRIPTION
  - Properly set login/password to repository url
    They were not correctly escaped before

  - Use git reset --hard to checkout because we were trying
    to change (badly) the HEAD which is what reset does

  - Simplify + Handle all errors instead of swallowing them

  - Add some tests