### PR TITLE
tests: remove audit rs checks for the time being

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,14 +11,6 @@ concurrency:
   group: ${{ github.ref }}
 
 jobs:
-  security_audit:
-    runs-on: ubuntu-latest
-    continue-on-error: true
-    steps:
-      - uses: actions/checkout@v1
-      - uses: actions-rs/audit-check@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
   build-linter-utests:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Deactivating cargo audit for the time being as couple libraries raises some errors (DO lib). We will re-activate this check once moved out of those libs.

Ticket: ENG-1089