### PR TITLE
feat: lower restarts to delete crashlooping pods

### DIFF
--- a/src/cloud_provider/aws/kubernetes/mod.rs
+++ b/src/cloud_provider/aws/kubernetes/mod.rs
@@ -1404,7 +1404,7 @@ impl<'a> Kubernetes for EKS<'a> {
         if let Err(e) = self.delete_crashlooping_pods(
             None,
             None,
-            Some(10),
+            Some(3),
             self.cloud_provider().credentials_environment_variables(),
         ) {
             error!(

--- a/src/cloud_provider/digitalocean/kubernetes/mod.rs
+++ b/src/cloud_provider/digitalocean/kubernetes/mod.rs
@@ -1229,7 +1229,7 @@ impl<'a> Kubernetes for DOKS<'a> {
         match self.delete_crashlooping_pods(
             None,
             None,
-            Some(10),
+            Some(3),
             self.cloud_provider().credentials_environment_variables(),
         ) {
             Ok(..) => {}

--- a/src/cloud_provider/scaleway/kubernetes/mod.rs
+++ b/src/cloud_provider/scaleway/kubernetes/mod.rs
@@ -1183,7 +1183,7 @@ impl<'a> Kubernetes for Kapsule<'a> {
         match self.delete_crashlooping_pods(
             None,
             None,
-            Some(10),
+            Some(3),
             self.cloud_provider().credentials_environment_variables(),
         ) {
             Ok(..) => {}


### PR DESCRIPTION
This CL lowers down the number of crashlooping pods restarts to be
consired as to be deleted from 5 to 3.