### PR TITLE
fix build args injection while building docker image

### DIFF
--- a/src/build_platform/docker.rs
+++ b/src/build_platform/docker.rs
@@ -43,14 +43,16 @@ pub fn match_used_env_var_args(
     let used_args = extract_dockerfile_args(dockerfile_content)?;
 
     // match env var args and dockerfile env vargs
-    let env_var_arg_keys = env_var_args.iter()
+    let env_var_arg_keys = env_var_args
+        .iter()
         .map(|env_var| {
             let x = env_var.split("=").collect::<Vec<&str>>();
             x.get(0).unwrap_or(&"").to_string()
         })
         .collect::<HashSet<String>>();
 
-    Ok(env_var_arg_keys.intersection(&used_args)
+    Ok(env_var_arg_keys
+        .intersection(&used_args)
         .map(|arg| arg.clone())
         .collect::<Vec<String>>())
 }
@@ -118,7 +120,10 @@ mod tests {
 
         assert_eq!(matched_vars.unwrap().len(), 4);
 
-        let matched_vars = match_used_env_var_args(vec!["toto=abcdvalue".to_string(), "x=abcdvalue".to_string()], dockerfile.to_vec());
+        let matched_vars = match_used_env_var_args(
+            vec!["toto=abcdvalue".to_string(), "x=abcdvalue".to_string()],
+            dockerfile.to_vec(),
+        );
 
         assert_eq!(matched_vars.unwrap().len(), 2);
 
@@ -188,7 +193,8 @@ mod tests {
 
         assert_eq!(matched_vars.unwrap().len(), 3);
 
-        let matched_vars = match_used_env_var_args(vec!["PRISMIC_REPO_NAME=abcdvalue".to_string()], dockerfile.to_vec());
+        let matched_vars =
+            match_used_env_var_args(vec!["PRISMIC_REPO_NAME=abcdvalue".to_string()], dockerfile.to_vec());
 
         assert_eq!(matched_vars.unwrap().len(), 1);
 

--- a/src/build_platform/docker.rs
+++ b/src/build_platform/docker.rs
@@ -1,5 +1,4 @@
 use std::collections::HashSet;
-use std::iter::FromIterator;
 use std::str::Utf8Error;
 
 /// Extract ARG value from a Dockerfile content
@@ -34,6 +33,8 @@ pub fn extract_dockerfile_args(dockerfile_content: Vec<u8>) -> Result<HashSet<St
 }
 
 /// Return env var args that are really used in the Dockerfile
+/// env_var_args is a vector of value "key=value".
+/// which is the format of the value expected by docker with the argument "build-arg"
 pub fn match_used_env_var_args(
     env_var_args: Vec<String>,
     dockerfile_content: Vec<u8>,
@@ -42,8 +43,14 @@ pub fn match_used_env_var_args(
     let used_args = extract_dockerfile_args(dockerfile_content)?;
 
     // match env var args and dockerfile env vargs
-    Ok(HashSet::from_iter(env_var_args)
-        .intersection(&used_args)
+    let env_var_arg_keys = env_var_args.iter()
+        .map(|env_var| {
+            let x = env_var.split("=").collect::<Vec<&str>>();
+            x.get(0).unwrap_or(&"").to_string()
+        })
+        .collect::<HashSet<String>>();
+
+    Ok(env_var_arg_keys.intersection(&used_args)
         .map(|arg| arg.clone())
         .collect::<Vec<String>>())
 }
@@ -101,17 +108,17 @@ mod tests {
 
         let matched_vars = match_used_env_var_args(
             vec![
-                "foo".to_string(),
-                "bar".to_string(),
-                "toto".to_string(),
-                "x".to_string(),
+                "foo=abcdvalue".to_string(),
+                "bar=abcdvalue".to_string(),
+                "toto=abcdvalue".to_string(),
+                "x=abcdvalue".to_string(),
             ],
             dockerfile.to_vec(),
         );
 
         assert_eq!(matched_vars.unwrap().len(), 4);
 
-        let matched_vars = match_used_env_var_args(vec!["toto".to_string(), "x".to_string()], dockerfile.to_vec());
+        let matched_vars = match_used_env_var_args(vec!["toto=abcdvalue".to_string(), "x=abcdvalue".to_string()], dockerfile.to_vec());
 
         assert_eq!(matched_vars.unwrap().len(), 2);
 
@@ -128,13 +135,64 @@ mod tests {
 
         let matched_vars = match_used_env_var_args(
             vec![
-                "foo".to_string(),
-                "bar".to_string(),
-                "toto".to_string(),
-                "x".to_string(),
+                "foo=abcdvalue".to_string(),
+                "bar=abcdvalue".to_string(),
+                "toto=abcdvalue".to_string(),
+                "x=abcdvalue".to_string(),
             ],
             dockerfile.to_vec(),
         );
+
+        assert_eq!(matched_vars.unwrap().len(), 0);
+    }
+
+    #[test]
+    fn test_match_used_env_var_args_2() {
+        let dockerfile = b"
+        # This file is a template, and might need editing before it works on your project.
+        FROM node:16-alpine as build
+
+        WORKDIR /app
+        COPY . .
+
+            ARG PRISMIC_REPO_NAME
+        ENV PRISMIC_REPO_NAME $PRISMIC_REPO_NAME
+
+        ARG PRISMIC_API_KEY
+        ENV PRISMIC_API_KEY $PRISMIC_API_KEY
+
+        ARG PRISMIC_CUSTOM_TYPES_API_TOKEN
+        ENV PRISMIC_CUSTOM_TYPES_API_TOKEN $PRISMIC_CUSTOM_TYPES_API_TOKEN
+
+        RUN npm install && npm run build
+
+        FROM nginx:latest
+        COPY --from=build /app/public /usr/share/nginx/html
+        COPY ./nginx-custom.conf /etc/nginx/conf.d/default.conf
+
+        EXPOSE 80
+        CMD [\"nginx\", \"-g\", \"daemon off;\"]
+        ";
+
+        let res = extract_dockerfile_args(dockerfile.to_vec());
+        assert_eq!(res.unwrap().len(), 3);
+
+        let matched_vars = match_used_env_var_args(
+            vec![
+                "PRISMIC_REPO_NAME=abcdvalue".to_string(),
+                "PRISMIC_API_KEY=abcdvalue".to_string(),
+                "PRISMIC_CUSTOM_TYPES_API_TOKEN=abcdvalue".to_string(),
+            ],
+            dockerfile.to_vec(),
+        );
+
+        assert_eq!(matched_vars.unwrap().len(), 3);
+
+        let matched_vars = match_used_env_var_args(vec!["PRISMIC_REPO_NAME=abcdvalue".to_string()], dockerfile.to_vec());
+
+        assert_eq!(matched_vars.unwrap().len(), 1);
+
+        let matched_vars = match_used_env_var_args(vec![], dockerfile.to_vec());
 
         assert_eq!(matched_vars.unwrap().len(), 0);
     }

--- a/src/build_platform/docker.rs
+++ b/src/build_platform/docker.rs
@@ -46,8 +46,8 @@ pub fn match_used_env_var_args(
     let env_var_arg_keys = env_var_args
         .iter()
         .map(|env_var| {
-            let x = env_var.split("=").collect::<Vec<&str>>();
-            x.get(0).unwrap_or(&"").to_string()
+            let x = env_var.split("=").next();
+            x.unwrap_or(&"").to_string()
         })
         .collect::<HashSet<String>>();
 


### PR DESCRIPTION
Hi, here is a fix for build args injection while building a Docker image. It didn't work because of the bad assumptions of the format of `env_var_args`. 