### PR TITLE
fix: service to be created even if private port

### DIFF
--- a/lib/aws/charts/q-application/templates/service.j2.yaml
+++ b/lib/aws/charts/q-application/templates/service.j2.yaml
@@ -1,4 +1,3 @@
-{%- if is_private_port %}
 apiVersion: v1
 kind: Service
 metadata:
@@ -23,4 +22,3 @@ spec:
     appId: {{ id }}
     app: {{ sanitized_name }}
     envId: {{ environment_id }}
-{% endif %}

--- a/lib/digitalocean/charts/q-application/templates/service.j2.yaml
+++ b/lib/digitalocean/charts/q-application/templates/service.j2.yaml
@@ -1,4 +1,3 @@
-{%- if is_private_port %}
 apiVersion: v1
 kind: Service
 metadata:
@@ -23,4 +22,3 @@ spec:
     appId: {{ id }}
     app: {{ sanitized_name }}
     envId: {{ environment_id }}
-{% endif %}

--- a/lib/scaleway/charts/q-application/templates/service.j2.yaml
+++ b/lib/scaleway/charts/q-application/templates/service.j2.yaml
@@ -1,4 +1,3 @@
-{%- if is_private_port %}
 apiVersion: v1
 kind: Service
 metadata:
@@ -23,4 +22,3 @@ spec:
     appId: {{ id }}
     app: {{ sanitized_name }}
     envId: {{ environment_id }}
-{% endif %}


### PR DESCRIPTION
As of today if port is set as private on an app / db, then no service
will be created for it in k8s. This should not be the case and a service
should be created even if app or db is flagged as private allowing other
internal apps to connect to it.