### PR TITLE
Fix rbac for shell-agent

### DIFF
--- a/lib/common/bootstrap/charts/qovery-shell-agent/templates/clusterrole.yaml
+++ b/lib/common/bootstrap/charts/qovery-shell-agent/templates/clusterrole.yaml
@@ -19,5 +19,7 @@ rules:
     resources:
       - pods/exec
     verbs:
+      - get
+      - list
       - create
 {{- end }}


### PR DESCRIPTION
  + Some kube lib (i.e: kube-rs) is doing a get before doing
    a create