### PR TITLE
fix: handle services without ports defined

### DIFF
--- a/lib/aws/charts/q-application/templates/service.j2.yaml
+++ b/lib/aws/charts/q-application/templates/service.j2.yaml
@@ -1,3 +1,4 @@
+{%- if (ports is defined) and ports %}
 apiVersion: v1
 kind: Service
 metadata:
@@ -22,3 +23,4 @@ spec:
     appId: {{ id }}
     app: {{ sanitized_name }}
     envId: {{ environment_id }}
+{%- endif %}

--- a/lib/digitalocean/charts/q-application/templates/service.j2.yaml
+++ b/lib/digitalocean/charts/q-application/templates/service.j2.yaml
@@ -1,3 +1,4 @@
+{%- if (ports is defined) and ports %}
 apiVersion: v1
 kind: Service
 metadata:
@@ -22,3 +23,4 @@ spec:
     appId: {{ id }}
     app: {{ sanitized_name }}
     envId: {{ environment_id }}
+{%- endif %}

--- a/lib/scaleway/charts/q-application/templates/service.j2.yaml
+++ b/lib/scaleway/charts/q-application/templates/service.j2.yaml
@@ -1,3 +1,4 @@
+{%- if (ports is defined) and ports %}
 apiVersion: v1
 kind: Service
 metadata:
@@ -22,3 +23,4 @@ spec:
     appId: {{ id }}
     app: {{ sanitized_name }}
     envId: {{ environment_id }}
+{%- endif %}


### PR DESCRIPTION
This CL fixes a bug: in case there is no port defined in service, it produces an invalid YAML. This fix prevent service to be created in case there is no ports defined.