### PR TITLE
conf: increase default helm timeout

### DIFF
--- a/src/cloud_provider/helm.rs
+++ b/src/cloud_provider/helm.rs
@@ -130,7 +130,7 @@ impl Default for ChartInfo {
             atomic: true,
             force_upgrade: false,
             last_breaking_version_requiring_restart: None,
-            timeout_in_seconds: 180,
+            timeout_in_seconds: 300,
             dry_run: false,
             wait: true,
             values: Vec::new(),


### PR DESCRIPTION
This CL increases default helm chart timeout from 180 seconds to 300 seconds.