### PR TITLE
Fix: AWS managed database are never private

### DIFF
--- a/lib/aws/services/common/common-variables.j2.tf
+++ b/lib/aws/services/common/common-variables.j2.tf
@@ -81,7 +81,7 @@ variable "snapshot_identifier" {
 
 variable "publicly_accessible" {
   description = "Instance publicly accessible"
-  default = true
+  default = {{ publicly_accessible }}
   type = bool
 }
 

--- a/lib/aws/services/redis/main.j2.tf
+++ b/lib/aws/services/redis/main.j2.tf
@@ -56,8 +56,8 @@ resource "helm_release" "elasticache_instance_external_name" {
   }
 
   set {
-    name= "publicly_accessible"
-    value= {{ publicly_accessible }}
+    name = "publicly_accessible"
+    value = var.publicly_accessible
   }
 
   depends_on = [


### PR DESCRIPTION
Postgres, mysql use the var.publicly_accesible terraform variable, but this one is never set outside of the default true