### PR TITLE
Fix: execute correct check action during deployment

### DIFF
--- a/src/cloud_provider/kubernetes.rs
+++ b/src/cloud_provider/kubernetes.rs
@@ -411,7 +411,7 @@ pub fn deploy_environment(
 
         // check all deployed services
         let _ = service::check_kubernetes_service_error(
-            service.on_create_check(),
+            service.exec_check_action(),
             kubernetes,
             service,
             event_details.clone(),
@@ -449,11 +449,11 @@ pub fn deploy_environment(
 
         // check all deployed services
         let _ = service::check_kubernetes_service_error(
-            service.on_create_check(),
+            service.exec_check_action(),
             kubernetes,
             service,
             event_details.clone(),
-            &stateful_deployment_target,
+            &stateless_deployment_target,
             &listeners_helper,
             "check deployment",
             CheckAction::Deploy,

--- a/src/cloud_provider/service.rs
+++ b/src/cloud_provider/service.rs
@@ -144,6 +144,15 @@ pub trait StatelessService: Service + Create + Pause + Delete {
             crate::cloud_provider::service::Action::Nothing => Ok(()),
         }
     }
+
+    fn exec_check_action(&self) -> Result<(), EngineError> {
+        match self.action() {
+            crate::cloud_provider::service::Action::Create => self.on_create_check(),
+            crate::cloud_provider::service::Action::Delete => self.on_delete_check(),
+            crate::cloud_provider::service::Action::Pause => self.on_pause_check(),
+            crate::cloud_provider::service::Action::Nothing => Ok(()),
+        }
+    }
 }
 
 pub trait StatefulService: Service + Create + Pause + Delete {
@@ -152,6 +161,15 @@ pub trait StatefulService: Service + Create + Pause + Delete {
             crate::cloud_provider::service::Action::Create => self.on_create(deployment_target),
             crate::cloud_provider::service::Action::Delete => self.on_delete(deployment_target),
             crate::cloud_provider::service::Action::Pause => self.on_pause(deployment_target),
+            crate::cloud_provider::service::Action::Nothing => Ok(()),
+        }
+    }
+
+    fn exec_check_action(&self) -> Result<(), EngineError> {
+        match self.action() {
+            crate::cloud_provider::service::Action::Create => self.on_create_check(),
+            crate::cloud_provider::service::Action::Delete => self.on_delete_check(),
+            crate::cloud_provider::service::Action::Pause => self.on_pause_check(),
             crate::cloud_provider::service::Action::Nothing => Ok(()),
         }
     }


### PR DESCRIPTION
we were always executing the create check action, even in case of pause/delete
