### PR TITLE
feat: logger to send full execution ID

### DIFF
--- a/src/logger.rs
+++ b/src/logger.rs
@@ -40,13 +40,14 @@ impl Logger for StdIoLogger {
     fn log(&self, log_level: LogLevel, event: EngineEvent) {
         let event_details = event.get_details();
         let stage = event_details.stage();
+        let execution_id = event_details.execution_id().to_string();
 
         tracing::span!(
             tracing::Level::INFO,
             "std_io_logger",
             organization_id = event_details.organisation_id().short(),
             cluster_id = event_details.cluster_id().short(),
-            execution_id = event_details.execution_id().short(),
+            execution_id = execution_id.as_str(),
             provider = match event_details.provider_kind() {
                 Some(kind) => kind.to_string(),
                 None => "".to_string(),
@@ -215,7 +216,7 @@ mod tests {
                 tc.description
             );
             assert!(
-                logs_contain(format!("execution_id=\"{}\"", execution_id.short()).as_str()),
+                logs_contain(format!("execution_id=\"{}\"", execution_id.to_string()).as_str()),
                 "{}",
                 tc.description
             );


### PR DESCRIPTION
New STD IO logging system sends short version of the execution ID, but
it's better to have its full version for convenience.