### PR TITLE
refactor: ease event message safe / unsafe logic

### DIFF
--- a/src/cloud_provider/aws/kubernetes/mod.rs
+++ b/src/cloud_provider/aws/kubernetes/mod.rs
@@ -835,7 +835,10 @@ impl<'a> EKS<'a> {
             ),
             Err(err) => self.logger().log(
                 LogLevel::Error,
-                EngineEvent::Deploying(event_details.clone(), EventMessage::new(err.message(), None)),
+                EngineEvent::Deploying(
+                    event_details.clone(),
+                    EventMessage::new("Error trying to get kubernetes events".to_string(), Some(err.message())),
+                ),
             ),
         };
 
@@ -1110,10 +1113,7 @@ impl<'a> EKS<'a> {
                     LogLevel::Warning,
                     EngineEvent::Deleting(
                         event_details.clone(),
-                        EventMessage::new(
-                            format!("{}, error: {}", safe_message.to_string(), e.message()),
-                            Some(safe_message.to_string()),
-                        ),
+                        EventMessage::new(safe_message.to_string(), Some(e.message())),
                     ),
                 );
 
@@ -1226,7 +1226,7 @@ impl<'a> EKS<'a> {
                         LogLevel::Error,
                         EngineEvent::Deleting(
                             event_details.clone(),
-                            EventMessage::new(format!("{}, error: {}", message_safe, e.message(),), Some(message_safe)),
+                            EventMessage::new(message_safe, Some(e.message())),
                         ),
                     );
                 }
@@ -1299,10 +1299,7 @@ impl<'a> EKS<'a> {
                                         LogLevel::Error,
                                         EngineEvent::Deleting(
                                             event_details.clone(),
-                                            EventMessage::new(
-                                                format!("{}, error: {}", message_safe, e.message()),
-                                                Some(message_safe),
-                                            ),
+                                            EventMessage::new(message_safe, Some(e.message())),
                                         ),
                                     )
                                 }
@@ -1398,14 +1395,7 @@ impl<'a> EKS<'a> {
                                     LogLevel::Error,
                                     EngineEvent::Deleting(
                                         event_details.clone(),
-                                        EventMessage::new(
-                                            format!(
-                                                "{}, error: {}",
-                                                message_safe,
-                                                e.message.unwrap_or("no error message".to_string())
-                                            ),
-                                            Some(message_safe),
-                                        ),
+                                        EventMessage::new(message_safe, e.message),
                                     ),
                                 )
                             }
@@ -1418,10 +1408,7 @@ impl<'a> EKS<'a> {
                         LogLevel::Error,
                         EngineEvent::Deleting(
                             event_details.clone(),
-                            EventMessage::new(
-                                format!("{}, error: {}", message_safe, e.message()),
-                                Some(message_safe.to_string()),
-                            ),
+                            EventMessage::new(message_safe.to_string(), Some(e.message())),
                         ),
                     )
                 }

--- a/src/cloud_provider/digitalocean/kubernetes/mod.rs
+++ b/src/cloud_provider/digitalocean/kubernetes/mod.rs
@@ -850,7 +850,10 @@ impl<'a> DOKS<'a> {
             ),
             Err(err) => self.logger().log(
                 LogLevel::Error,
-                EngineEvent::Deploying(event_details.clone(), EventMessage::new(err.message(), None)),
+                EngineEvent::Deploying(
+                    event_details.clone(),
+                    EventMessage::new("Error trying to get kubernetes events".to_string(), Some(err.message())),
+                ),
             ),
         };
 
@@ -962,10 +965,7 @@ impl<'a> DOKS<'a> {
                     LogLevel::Warning,
                     EngineEvent::Deleting(
                         event_details.clone(),
-                        EventMessage::new(
-                            format!("{}, error: {}", safe_message.to_string(), e.message()),
-                            Some(safe_message.to_string()),
-                        ),
+                        EventMessage::new(safe_message.to_string(), Some(e.message())),
                     ),
                 );
 
@@ -1078,7 +1078,7 @@ impl<'a> DOKS<'a> {
                         LogLevel::Error,
                         EngineEvent::Deleting(
                             event_details.clone(),
-                            EventMessage::new(format!("{}, error: {}", message_safe, e.message(),), Some(message_safe)),
+                            EventMessage::new(message_safe, Some(e.message())),
                         ),
                     );
                 }
@@ -1151,10 +1151,7 @@ impl<'a> DOKS<'a> {
                                         LogLevel::Error,
                                         EngineEvent::Deleting(
                                             event_details.clone(),
-                                            EventMessage::new(
-                                                format!("{}, error: {}", message_safe, e.message(),),
-                                                Some(message_safe),
-                                            ),
+                                            EventMessage::new(message_safe, Some(e.message())),
                                         ),
                                     )
                                 }
@@ -1250,14 +1247,7 @@ impl<'a> DOKS<'a> {
                                     LogLevel::Error,
                                     EngineEvent::Deleting(
                                         event_details.clone(),
-                                        EventMessage::new(
-                                            format!(
-                                                "{}, error: {}",
-                                                message_safe,
-                                                e.message.unwrap_or("no error message".to_string())
-                                            ),
-                                            Some(message_safe),
-                                        ),
+                                        EventMessage::new(message_safe, e.message),
                                     ),
                                 )
                             }
@@ -1270,10 +1260,7 @@ impl<'a> DOKS<'a> {
                         LogLevel::Error,
                         EngineEvent::Deleting(
                             event_details.clone(),
-                            EventMessage::new(
-                                format!("{}, error: {}", message_safe, e.message()),
-                                Some(message_safe.to_string()),
-                            ),
+                            EventMessage::new(message_safe.to_string(), Some(e.message())),
                         ),
                     )
                 }

--- a/src/cloud_provider/kubernetes.rs
+++ b/src/cloud_provider/kubernetes.rs
@@ -764,12 +764,8 @@ where
                 EngineEvent::Deleting(
                     event_details.clone(),
                     EventMessage::new(
-                        format!(
-                            "Encountering issues while trying to get objects kind {}: {:?}",
-                            object,
-                            e.message()
-                        ),
-                        None,
+                        format!("Encountering issues while trying to get objects kind {}.", object,),
+                        Some(e.message()),
                     ),
                 ),
             );
@@ -786,7 +782,10 @@ where
                         LogLevel::Warning,
                         EngineEvent::Deleting(
                             event_details.clone(),
-                            EventMessage::new(format!("Failed to delete all {} objects, retrying...", object,), None),
+                            EventMessage::new_from_safe(format!(
+                                "Failed to delete all {} objects, retrying...",
+                                object,
+                            )),
                         ),
                     );
                     OperationResult::Retry(e)
@@ -1039,7 +1038,7 @@ fn check_kubernetes_upgrade_status(
             if let Some(msg) = x.message {
                 logger.log(
                     LogLevel::Info,
-                    EngineEvent::Deploying(event_details.clone(), EventMessage::new(msg, None)),
+                    EngineEvent::Deploying(event_details.clone(), EventMessage::new_from_safe(msg)),
                 );
             };
             if x.older_version_detected {
@@ -1067,9 +1066,8 @@ fn check_kubernetes_upgrade_status(
             LogLevel::Warning,
             EngineEvent::Deploying(
                 event_details.clone(),
-                EventMessage::new(
+                EventMessage::new_from_safe(
                     "No worker nodes found, can't check if upgrade is required for workers".to_string(),
-                    None,
                 ),
             ),
         );
@@ -1120,19 +1118,16 @@ fn check_kubernetes_upgrade_status(
         LogLevel::Info,
         EngineEvent::Deploying(
             event_details.clone(),
-            EventMessage::new(
-                match &required_upgrade_on {
-                    None => "All workers are up to date, no upgrade required".to_string(),
-                    Some(node_type) => match node_type {
-                        KubernetesNodesType::Masters => "Kubernetes master upgrade required".to_string(),
-                        KubernetesNodesType::Workers => format!(
-                            "Kubernetes workers upgrade required, need to update {}/{} nodes",
-                            non_up_to_date_workers, total_workers
-                        ),
-                    },
+            EventMessage::new_from_safe(match &required_upgrade_on {
+                None => "All workers are up to date, no upgrade required".to_string(),
+                Some(node_type) => match node_type {
+                    KubernetesNodesType::Masters => "Kubernetes master upgrade required".to_string(),
+                    KubernetesNodesType::Workers => format!(
+                        "Kubernetes workers upgrade required, need to update {}/{} nodes",
+                        non_up_to_date_workers, total_workers
+                    ),
                 },
-                None,
-            ),
+            }),
         ),
     );
 

--- a/src/cloud_provider/scaleway/kubernetes/mod.rs
+++ b/src/cloud_provider/scaleway/kubernetes/mod.rs
@@ -677,11 +677,14 @@ impl<'a> Kapsule<'a> {
         match kubectl_exec_get_events(kubeconfig_path, None, environment_variables) {
             Ok(ok_line) => self.logger().log(
                 LogLevel::Info,
-                EngineEvent::Deploying(event_details.clone(), EventMessage::new(ok_line, None)),
+                EngineEvent::Deploying(event_details.clone(), EventMessage::new_from_safe(ok_line)),
             ),
             Err(err) => self.logger().log(
                 LogLevel::Error,
-                EngineEvent::Deploying(event_details.clone(), EventMessage::new(err.message(), None)),
+                EngineEvent::Deploying(
+                    event_details.clone(),
+                    EventMessage::new("Error trying to get kubernetes events".to_string(), Some(err.message())),
+                ),
             ),
         };
 
@@ -957,10 +960,7 @@ impl<'a> Kapsule<'a> {
                     LogLevel::Warning,
                     EngineEvent::Deleting(
                         event_details.clone(),
-                        EventMessage::new(
-                            format!("{}, error: {}", safe_message.to_string(), e.message()),
-                            Some(safe_message.to_string()),
-                        ),
+                        EventMessage::new(safe_message.to_string(), Some(e.message())),
                     ),
                 );
                 skip_kubernetes_step = true;
@@ -1072,7 +1072,7 @@ impl<'a> Kapsule<'a> {
                         LogLevel::Error,
                         EngineEvent::Deleting(
                             event_details.clone(),
-                            EventMessage::new(format!("{}, error: {}", message_safe, e.message()), Some(message_safe)),
+                            EventMessage::new(message_safe, Some(e.message())),
                         ),
                     );
                 }
@@ -1145,10 +1145,7 @@ impl<'a> Kapsule<'a> {
                                         LogLevel::Error,
                                         EngineEvent::Deleting(
                                             event_details.clone(),
-                                            EventMessage::new(
-                                                format!("{}, error: {}", message_safe, e.message()),
-                                                Some(message_safe),
-                                            ),
+                                            EventMessage::new(message_safe, Some(e.message())),
                                         ),
                                     )
                                 }
@@ -1244,14 +1241,7 @@ impl<'a> Kapsule<'a> {
                                     LogLevel::Error,
                                     EngineEvent::Deleting(
                                         event_details.clone(),
-                                        EventMessage::new(
-                                            format!(
-                                                "{}, error: {}",
-                                                message_safe,
-                                                e.message.unwrap_or("no error message".to_string())
-                                            ),
-                                            Some(message_safe),
-                                        ),
+                                        EventMessage::new(message_safe, e.message),
                                     ),
                                 )
                             }
@@ -1264,10 +1254,7 @@ impl<'a> Kapsule<'a> {
                         LogLevel::Error,
                         EngineEvent::Deleting(
                             event_details.clone(),
-                            EventMessage::new(
-                                format!("{}, error: {}", message_safe, e.message()),
-                                Some(message_safe.to_string()),
-                            ),
+                            EventMessage::new(message_safe.to_string(), Some(e.message())),
                         ),
                     )
                 }

--- a/src/events/io.rs
+++ b/src/events/io.rs
@@ -81,15 +81,15 @@ impl From<events::EngineEvent> for EngineEvent {
 #[derive(Deserialize, Serialize)]
 #[serde(rename_all = "lowercase")]
 pub struct EventMessage {
-    raw: String,
-    safe: Option<String>,
+    safe_message: String,
+    full_details: Option<String>,
 }
 
 impl From<events::EventMessage> for EventMessage {
     fn from(message: events::EventMessage) -> Self {
         EventMessage {
-            raw: message.raw,
-            safe: message.safe,
+            safe_message: message.safe_message,
+            full_details: message.full_details,
         }
     }
 }

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -1,4 +1,4 @@
-use crate::events::EngineEvent;
+use crate::events::{EngineEvent, EventMessageVerbosity};
 use tracing;
 
 #[derive(Debug, Clone)]
@@ -63,10 +63,10 @@ impl Logger for StdIoLogger {
         )
         .in_scope(|| {
             match log_level {
-                LogLevel::Debug => debug!("{}", event.get_message()),
-                LogLevel::Info => info!("{}", event.get_message()),
-                LogLevel::Warning => warn!("{}", event.get_message()),
-                LogLevel::Error => error!("{}", event.get_message()),
+                LogLevel::Debug => debug!("{}", event.message(EventMessageVerbosity::FullDetails)),
+                LogLevel::Info => info!("{}", event.message(EventMessageVerbosity::FullDetails)),
+                LogLevel::Warning => warn!("{}", event.message(EventMessageVerbosity::FullDetails)),
+                LogLevel::Error => error!("{}", event.message(EventMessageVerbosity::FullDetails)),
             };
         });
     }
@@ -107,8 +107,8 @@ mod tests {
         let app_name = format!("simple-app-{}", app_id);
         let qovery_message = "Qovery message";
         let user_message = "User message";
+        let safe_message = "Safe message";
         let raw_message = "Raw message";
-        let raw_message_safe = "Raw message safe";
         let link = Url::parse("https://qovery.com").expect("cannot parse Url");
         let hint = "An hint !";
 
@@ -128,8 +128,8 @@ mod tests {
                     qovery_message.to_string(),
                     user_message.to_string(),
                     Some(errors::CommandError::new(
-                        raw_message.to_string(),
-                        Some(raw_message_safe.to_string()),
+                        safe_message.to_string(),
+                        Some(raw_message.to_string()),
                     )),
                     Some(link.clone()),
                     Some(hint.to_string()),
@@ -148,7 +148,7 @@ mod tests {
                         Stage::Infrastructure(InfrastructureStep::Create),
                         Transmitter::Kubernetes(cluster_id.to_string(), cluster_name.to_string()),
                     ),
-                    EventMessage::new(raw_message.to_string(), Some(raw_message_safe.to_string())),
+                    EventMessage::new(raw_message.to_string(), Some(safe_message.to_string())),
                 ),
                 description: "Deploying info event",
             },
@@ -164,7 +164,7 @@ mod tests {
                         Stage::Environment(EnvironmentStep::Pause),
                         Transmitter::Application(app_id.to_string(), app_name.to_string()),
                     ),
-                    EventMessage::new(raw_message.to_string(), Some(raw_message_safe.to_string())),
+                    EventMessage::new(raw_message.to_string(), Some(safe_message.to_string())),
                 ),
                 description: "Pausing application debug event",
             },
@@ -180,7 +180,7 @@ mod tests {
                         Stage::Environment(EnvironmentStep::Delete),
                         Transmitter::Application(app_id.to_string(), app_name.to_string()),
                     ),
-                    EventMessage::new(raw_message.to_string(), Some(raw_message_safe.to_string())),
+                    EventMessage::new(raw_message.to_string(), Some(safe_message.to_string())),
                 ),
                 description: "Deleting application warning event",
             },
@@ -267,8 +267,9 @@ mod tests {
                 tc.description
             );
 
-            let message = tc.event.get_message().to_string();
-            assert!(logs_contain(&message), "{}", tc.description);
+            // Logger should display everything
+            assert!(logs_contain(safe_message), "{}", tc.description);
+            assert!(logs_contain(raw_message), "{}", tc.description);
         }
     }
 }


### PR DESCRIPTION
This CL aims to ease and simplify EventMessage usage making safe /
unsafe message more transparent to deal with.