### PR TITLE
fix: remove unknown param for SCW managed DB

### DIFF
--- a/lib/scaleway/services/mysql/main.j2.tf
+++ b/lib/scaleway/services/mysql/main.j2.tf
@@ -56,9 +56,6 @@ resource "scaleway_rdb_instance" "mysql_instance" {
 
   tags              = local.tags_mysql_list
 
-  publicly_accessible = var.publicly_accessible
-
-
 # TODO:(benjaminch): features to be added at some point but be discussed with Scaleway
   # - port
   # - instance create timeout

--- a/lib/scaleway/services/postgresql/main.j2.tf
+++ b/lib/scaleway/services/postgresql/main.j2.tf
@@ -56,9 +56,6 @@ resource "scaleway_rdb_instance" "postgresql_instance" {
 
   tags              = local.tags_postgresql_list
 
-  publicly_accessible = var.publicly_accessible
-
-
 # TODO:(benjaminch): features to be added at some point but be discussed with Scaleway
   # - port
   # - instance create timeout

--- a/test_utilities/src/common.rs
+++ b/test_utilities/src/common.rs
@@ -991,7 +991,7 @@ pub fn test_db(
 
     let app_id = generate_id();
     let database_username = "superuser".to_string();
-    let database_password = generate_id();
+    let database_password = generate_password(true);
     let db_kind_str = db_kind.name().to_string();
     let db_id = generate_id();
     let database_host = format!("{}-{}", db_id, db_kind_str.clone());

--- a/tests/scaleway/scw_databases.rs
+++ b/tests/scaleway/scw_databases.rs
@@ -675,7 +675,6 @@ fn private_postgresql_v10_deploy_a_working_prod_environment() {
 #[cfg(feature = "test-scw-managed-services")]
 #[named]
 #[test]
-#[ignore]
 fn public_postgresql_v10_deploy_a_working_prod_environment() {
     let secrets = FuncTestsSecrets::new();
     let context = context(
@@ -733,7 +732,6 @@ fn private_postgresql_v11_deploy_a_working_prod_environment() {
 #[cfg(feature = "test-scw-managed-services")]
 #[named]
 #[test]
-#[ignore]
 fn public_postgresql_v11_deploy_a_working_prod_environment() {
     let secrets = FuncTestsSecrets::new();
     let context = context(
@@ -791,7 +789,6 @@ fn private_postgresql_v12_deploy_a_working_prod_environment() {
 #[cfg(feature = "test-scw-managed-services")]
 #[named]
 #[test]
-#[ignore]
 fn public_postgresql_v12_deploy_a_working_prod_environment() {
     let secrets = FuncTestsSecrets::new();
     let context = context(
@@ -849,7 +846,6 @@ fn private_postgresql_v13_deploy_a_working_prod_environment() {
 #[cfg(feature = "test-scw-managed-services")]
 #[named]
 #[test]
-#[ignore]
 fn public_postgresql_v13_deploy_a_working_prod_environment() {
     let secrets = FuncTestsSecrets::new();
     let context = context(
@@ -1308,7 +1304,6 @@ fn private_mysql_v8_deploy_a_working_prod_environment() {
 #[cfg(feature = "test-scw-managed-services")]
 #[named]
 #[test]
-#[ignore]
 fn public_mysql_v8_deploy_a_working_prod_environment() {
     let secrets = FuncTestsSecrets::new();
     let context = context(

--- a/tests/scaleway/scw_databases.rs
+++ b/tests/scaleway/scw_databases.rs
@@ -675,6 +675,7 @@ fn private_postgresql_v10_deploy_a_working_prod_environment() {
 #[cfg(feature = "test-scw-managed-services")]
 #[named]
 #[test]
+#[ignore]
 fn public_postgresql_v10_deploy_a_working_prod_environment() {
     let secrets = FuncTestsSecrets::new();
     let context = context(
@@ -732,6 +733,7 @@ fn private_postgresql_v11_deploy_a_working_prod_environment() {
 #[cfg(feature = "test-scw-managed-services")]
 #[named]
 #[test]
+#[ignore]
 fn public_postgresql_v11_deploy_a_working_prod_environment() {
     let secrets = FuncTestsSecrets::new();
     let context = context(
@@ -789,6 +791,7 @@ fn private_postgresql_v12_deploy_a_working_prod_environment() {
 #[cfg(feature = "test-scw-managed-services")]
 #[named]
 #[test]
+#[ignore]
 fn public_postgresql_v12_deploy_a_working_prod_environment() {
     let secrets = FuncTestsSecrets::new();
     let context = context(
@@ -846,6 +849,7 @@ fn private_postgresql_v13_deploy_a_working_prod_environment() {
 #[cfg(feature = "test-scw-managed-services")]
 #[named]
 #[test]
+#[ignore]
 fn public_postgresql_v13_deploy_a_working_prod_environment() {
     let secrets = FuncTestsSecrets::new();
     let context = context(
@@ -1304,6 +1308,7 @@ fn private_mysql_v8_deploy_a_working_prod_environment() {
 #[cfg(feature = "test-scw-managed-services")]
 #[named]
 #[test]
+#[ignore]
 fn public_mysql_v8_deploy_a_working_prod_environment() {
     let secrets = FuncTestsSecrets::new();
     let context = context(


### PR DESCRIPTION
As of today, SCW doesn't support `is_publicly_accessible` tag on their
managed DB terraform provider nor any other tags related to DB access.

This CL fix this bug along with fixing SCW managed DB tests where those
requires strong passwords instead of Uuids in tests.