### PR TITLE
Terraform: Use same version of aws provider everywhere

### DIFF
--- a/lib/digitalocean/bootstrap/tf-providers.j2.tf
+++ b/lib/digitalocean/bootstrap/tf-providers.j2.tf
@@ -15,7 +15,7 @@ terraform {
   required_providers {
     aws = {
       source = "hashicorp/aws"
-      version    = "~> 3.36.0"
+      version    = "~> 3.66.0"
     }
     digitalocean = {
       source = "digitalocean/digitalocean"

--- a/lib/scaleway/bootstrap/tf-providers.j2.tf
+++ b/lib/scaleway/bootstrap/tf-providers.j2.tf
@@ -13,7 +13,7 @@ terraform {
     }
     aws = {
       source = "hashicorp/aws"
-      version = "~> 3.36.0"
+      version = "~> 3.66.0"
     }
     local = {
       source = "hashicorp/local"


### PR DESCRIPTION
For aws use v3.66.0, while not for do and scaleway, which require 400meg more of data in the container