### PR TITLE
feat: add ephemeral storage to engine

### DIFF
--- a/lib/common/bootstrap/charts/qovery-engine/templates/statefulset-deploy.yaml
+++ b/lib/common/bootstrap/charts/qovery-engine/templates/statefulset-deploy.yaml
@@ -112,6 +112,7 @@ spec:
               mountPath: {{ .Values.volumes.qoveryWorkspace.path }}
             - name: docker-graph-storage
               mountPath: {{ .Values.volumes.dockerGraphStorage.path }}
+  {{ if .Values.volumes.useNetworkDisks }}
   volumeClaimTemplates:
   - metadata:
       name: docker-graph-storage
@@ -135,4 +136,9 @@ spec:
       resources:
         requests:
           storage: {{ .Values.volumes.qoveryWorkspace.size }}
+  {{ else }}
+      volumes:
+        - name: docker-graph-storage
+          emptyDir: {}
+  {{ end }}
 {{ end }}

--- a/lib/common/bootstrap/charts/qovery-engine/values.yaml
+++ b/lib/common/bootstrap/charts/qovery-engine/values.yaml
@@ -32,6 +32,7 @@ environmentVariables:
   #REGION: ""
 
 volumes:
+  useNetworkDisks: true
   storageClassName: ""
   qoveryWorkspace:
     size: 20Gi
@@ -43,7 +44,7 @@ volumes:
 buildContainer:
   enable: true
   image: docker
-  tag: 20.10.11-dind
+  tag: 20.10.14-dind
 
 terminationGracePeriodSeconds: 7200
 
@@ -78,10 +79,11 @@ buildResources: {}
   # limits:
   #   cpu: 100m
   #   memory: 128Mi
+  #   ephemeral-storage: 40Gi
   # requests:
   #   cpu: 100m
   #   memory: 128Mi
-
+  #   ephemeral-storage: 40Gi
 
 nodeSelector: {}
 


### PR DESCRIPTION
In order to avoid using network storage, bringing random performances on container build, we're going to try local storage instead and see how it behaves