### PR TITLE
feat: add application commit ID to logs

### DIFF
--- a/lib/aws/charts/q-application/templates/deployment.j2.yaml
+++ b/lib/aws/charts/q-application/templates/deployment.j2.yaml
@@ -35,6 +35,7 @@ spec:
         app: {{ sanitized_name }}
       annotations:
         checksum/config: {% raw %}{{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}{% endraw %}
+        appCommitId: {{ version }}
     spec:
       affinity:
         podAntiAffinity:

--- a/lib/digitalocean/charts/q-application/templates/deployment.j2.yaml
+++ b/lib/digitalocean/charts/q-application/templates/deployment.j2.yaml
@@ -35,6 +35,7 @@ spec:
         app: {{ sanitized_name }}
       annotations:
         checksum/config: {% raw %}{{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}{% endraw %}
+        appCommitId: {{ version }}
     spec:
       affinity:
         podAntiAffinity:

--- a/lib/scaleway/charts/q-application/templates/deployment.j2.yaml
+++ b/lib/scaleway/charts/q-application/templates/deployment.j2.yaml
@@ -34,6 +34,7 @@ spec:
         app: {{ sanitized_name }}
       annotations:
         checksum/config: {% raw %}{{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}{% endraw %}
+        appCommitId: {{ version }}
     spec:
       affinity:
         podAntiAffinity:

--- a/src/cloud_provider/service.rs
+++ b/src/cloud_provider/service.rs
@@ -36,6 +36,9 @@ pub trait Service: ToTransmitter {
     fn name_with_id(&self) -> String {
         format!("{} ({})", self.name(), self.id())
     }
+    fn name_with_id_and_version(&self) -> String {
+        format!("{} ({}) version: {}", self.name(), self.id(), self.version())
+    }
     fn workspace_directory(&self) -> String {
         let dir_root = match self.service_type() {
             ServiceType::Application => "applications",
@@ -1215,17 +1218,17 @@ where
         Action::Create => Some(format!(
             "{} '{}' deployment is in progress...",
             service.service_type().name(),
-            service.name_with_id()
+            service.name_with_id_and_version(),
         )),
         Action::Pause => Some(format!(
             "{} '{}' pause is in progress...",
             service.service_type().name(),
-            service.name_with_id()
+            service.name_with_id_and_version(),
         )),
         Action::Delete => Some(format!(
             "{} '{}' deletion is in progress...",
             service.service_type().name(),
-            service.name_with_id()
+            service.name_with_id_and_version(),
         )),
         Action::Nothing => None,
     };

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,6 +4,7 @@ use std::process::ExitStatus;
 pub type Type = String;
 pub type Id = String;
 pub type Name = String;
+pub type Version = String;
 
 #[derive(Debug)]
 #[deprecated(note = "errors.EngineError to be used instead")]
@@ -44,7 +45,7 @@ pub enum EngineErrorScope {
     ObjectStorage(Id, Name),
     Environment(Id, Name),
     Database(Id, Type, Name),
-    Application(Id, Name),
+    Application(Id, Name, Version),
     Router(Id, Name),
 }
 
@@ -59,7 +60,7 @@ impl From<Transmitter> for EngineErrorScope {
             Transmitter::ObjectStorage(id, name) => EngineErrorScope::ObjectStorage(id, name),
             Transmitter::Environment(id, name) => EngineErrorScope::Environment(id, name),
             Transmitter::Database(id, db_type, name) => EngineErrorScope::Database(id, db_type, name),
-            Transmitter::Application(id, name) => EngineErrorScope::Application(id, name),
+            Transmitter::Application(id, name, commit) => EngineErrorScope::Application(id, name, commit),
             Transmitter::Router(id, name) => EngineErrorScope::Router(id, name),
         }
     }

--- a/src/errors/mod.rs
+++ b/src/errors/mod.rs
@@ -470,7 +470,7 @@ impl EngineError {
                     EngineErrorScope::ObjectStorage(id, name) => Transmitter::ObjectStorage(id, name),
                     EngineErrorScope::Environment(id, name) => Transmitter::Environment(id, name),
                     EngineErrorScope::Database(id, db_type, name) => Transmitter::Database(id, db_type, name),
-                    EngineErrorScope::Application(id, name) => Transmitter::Application(id, name),
+                    EngineErrorScope::Application(id, name, commit) => Transmitter::Application(id, name, commit),
                     EngineErrorScope::Router(id, name) => Transmitter::Router(id, name),
                 },
             ),

--- a/src/events/io.rs
+++ b/src/events/io.rs
@@ -163,6 +163,7 @@ impl From<events::EnvironmentStep> for EnvironmentStep {
 type TransmitterId = String;
 type TransmitterName = String;
 type TransmitterType = String;
+type TransmitterVersion = String;
 
 #[derive(Deserialize, Serialize)]
 #[serde(rename_all = "lowercase")]
@@ -204,6 +205,7 @@ pub enum Transmitter {
     Application {
         id: TransmitterId,
         name: TransmitterName,
+        commit: TransmitterVersion,
     },
     Router {
         id: TransmitterId,
@@ -222,7 +224,7 @@ impl From<events::Transmitter> for Transmitter {
             events::Transmitter::ObjectStorage(id, name) => Transmitter::ObjectStorage { id, name },
             events::Transmitter::Environment(id, name) => Transmitter::Environment { id, name },
             events::Transmitter::Database(id, db_type, name) => Transmitter::Database { id, db_type, name },
-            events::Transmitter::Application(id, name) => Transmitter::Application { id, name },
+            events::Transmitter::Application(id, name, commit) => Transmitter::Application { id, name, commit },
             events::Transmitter::Router(id, name) => Transmitter::Router { id, name },
         }
     }

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -326,6 +326,8 @@ type TransmitterId = String;
 type TransmitterName = String;
 /// TransmitterType: represents a transmitter type.
 type TransmitterType = String; // TODO(benjaminch): makes it a real enum / type
+/// TransmitterVersion: represents a transmitter version.
+type TransmitterVersion = String;
 
 #[derive(Debug, Clone, PartialEq)]
 /// Transmitter: represents the event's source caller (transmitter).
@@ -347,7 +349,7 @@ pub enum Transmitter {
     /// Database: database engine part.
     Database(TransmitterId, TransmitterType, TransmitterName),
     /// Application: application engine part.
-    Application(TransmitterId, TransmitterName),
+    Application(TransmitterId, TransmitterName, TransmitterVersion),
     /// Router: router engine part.
     Router(TransmitterId, TransmitterName),
 }
@@ -366,7 +368,8 @@ impl Display for Transmitter {
                 Transmitter::ObjectStorage(id, name) => format!("object_strorage({}, {})", id, name),
                 Transmitter::Environment(id, name) => format!("environment({}, {})", id, name),
                 Transmitter::Database(id, db_type, name) => format!("database({}, {}, {})", id, db_type, name),
-                Transmitter::Application(id, name) => format!("application({}, {})", id, name),
+                Transmitter::Application(id, name, version) =>
+                    format!("application({}, {}, commit: {})", id, name, version),
                 Transmitter::Router(id, name) => format!("router({}, {})", id, name),
             }
         )

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -97,6 +97,7 @@ mod tests {
         let execution_id = QoveryIdentifier::new_from_long_id(Uuid::new_v4().to_string());
         let app_id = QoveryIdentifier::new_from_long_id(Uuid::new_v4().to_string());
         let app_name = format!("simple-app-{}", app_id);
+        let app_version = Uuid::new_v4();
         let qovery_message = "Qovery message";
         let user_message = "User message";
         let safe_message = "Safe message";
@@ -155,7 +156,7 @@ mod tests {
                         execution_id.clone(),
                         Some(ScwRegion::Paris.as_str().to_string()),
                         Stage::Environment(EnvironmentStep::Pause),
-                        Transmitter::Application(app_id.to_string(), app_name.to_string()),
+                        Transmitter::Application(app_id.to_string(), app_name.to_string(), app_version.to_string()),
                     ),
                     EventMessage::new(raw_message.to_string(), Some(safe_message.to_string())),
                 ),
@@ -170,7 +171,7 @@ mod tests {
                         execution_id.clone(),
                         Some(ScwRegion::Paris.as_str().to_string()),
                         Stage::Environment(EnvironmentStep::Delete),
-                        Transmitter::Application(app_id.to_string(), app_name),
+                        Transmitter::Application(app_id.to_string(), app_name, app_version.to_string()),
                     ),
                     EventMessage::new(raw_message.to_string(), Some(safe_message.to_string())),
                 ),

--- a/src/models/application.rs
+++ b/src/models/application.rs
@@ -246,7 +246,7 @@ impl<T: CloudProvider> Application<T> {
 // Traits implementations
 impl<T: CloudProvider> ToTransmitter for Application<T> {
     fn to_transmitter(&self) -> Transmitter {
-        Transmitter::Application(self.id.to_string(), self.name.to_string())
+        Transmitter::Application(self.id.to_string(), self.name.to_string(), self.commit_id())
     }
 }
 
@@ -278,6 +278,10 @@ where
 
     fn name(&self) -> &str {
         self.name()
+    }
+
+    fn name_with_id_and_version(&self) -> String {
+        format!("{} ({}) commit: {}", self.name(), self.id(), self.commit_id())
     }
 
     fn sanitized_name(&self) -> String {


### PR DESCRIPTION
This CL adds:
- application commit ID to some application actions logs.
- application commit ID annotation / label to application deployment
  yaml so it can be retrieved later on from other services

Ticket: ENG-1170