### PR TITLE
Fix: revert clusterId to be a short id

### DIFF
--- a/lib/aws/bootstrap/eks-master-cluster.j2.tf
+++ b/lib/aws/bootstrap/eks-master-cluster.j2.tf
@@ -6,7 +6,8 @@ locals {
 
 locals {
   tags_common = {
-    ClusterId = var.kubernetes_full_cluster_id
+    ClusterId = var.kubernetes_cluster_id
+    ClusterLongId = var.kubernetes_full_cluster_id
     OrganizationId = var.organization_id,
     Region = var.region
     creationDate = time_static.on_cluster_create.rfc3339

--- a/lib/digitalocean/bootstrap/ks-locals.j2.tf
+++ b/lib/digitalocean/bootstrap/ks-locals.j2.tf
@@ -1,6 +1,7 @@
 locals {
   tags_ks = {
-    ClusterId      = var.kubernetes_full_cluster_id
+    ClusterId      = var.kubernetes_cluster_id
+    ClusterLongId  = var.kubernetes_full_cluster_id
     OrganizationId = var.organization_id,
     Region         = var.region
     creationDate   = time_static.on_cluster_create.rfc3339

--- a/lib/scaleway/bootstrap/ks-locals.j2.tf
+++ b/lib/scaleway/bootstrap/ks-locals.j2.tf
@@ -1,6 +1,7 @@
 locals {
   tags_ks = {
-    ClusterId      = var.kubernetes_full_cluster_id
+    ClusterId      = var.kubernetes_cluster_id
+    ClusterLongId  = var.kubernetes_full_cluster_id
     OrganizationId = var.organization_id,
     Region         = var.region
     creationDate   = time_static.on_cluster_create.rfc3339

--- a/src/cloud_provider/aws/kubernetes/mod.rs
+++ b/src/cloud_provider/aws/kubernetes/mod.rs
@@ -498,7 +498,7 @@ impl EKS {
         context.insert("eks_cidr_subnet", &eks_cidr_subnet);
         context.insert("kubernetes_cluster_name", &self.name());
         context.insert("kubernetes_cluster_id", self.id());
-        context.insert("kubernetes_full_cluster_id", self.context.cluster_id());
+        context.insert("kubernetes_full_cluster_id", &self.long_id);
         context.insert("eks_region_cluster_id", region_cluster_id.as_str());
         context.insert("eks_worker_nodes", &self.nodes_groups);
         context.insert("eks_zone_a_subnet_blocks_private", &eks_zone_a_subnet_blocks_private);

--- a/src/cloud_provider/scaleway/kubernetes/mod.rs
+++ b/src/cloud_provider/scaleway/kubernetes/mod.rs
@@ -468,7 +468,7 @@ impl Kapsule {
 
         // Kubernetes
         context.insert("test_cluster", &self.context.is_test_cluster());
-        context.insert("kubernetes_full_cluster_id", self.context().cluster_id());
+        context.insert("kubernetes_full_cluster_id", &self.long_id);
         context.insert("kubernetes_cluster_id", self.id());
         context.insert("kubernetes_cluster_name", self.cluster_name().as_str());
         context.insert("kubernetes_cluster_version", self.version());


### PR DESCRIPTION
  - Managed Databases use the clusterId in order find back the VPC